### PR TITLE
Improve dataloading by setting num_workers and pin_memory for diffusion training

### DIFF
--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -57,12 +57,16 @@ dataloader_train_hdvila = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_hdvila),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 dataloader_val_hdvila = L(DataLoader)(
     dataset=example_video_dataset_hdvila,
     sampler=L(get_sampler)(dataset=example_video_dataset_hdvila),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 
 # Cosmos-NeMo-Assets example
@@ -79,12 +83,16 @@ dataloader_train_cosmos_nemo_assets = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets,
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 
 

--- a/cosmos_predict1/diffusion/training/config/text2world_multiview/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world_multiview/experiment.py
@@ -151,12 +151,16 @@ text2world_multiview_7b_example_waymo = LazyDict(
             sampler=L(get_sampler)(dataset=example_multiview_dataset_waymo),
             batch_size=1,
             drop_last=True,
+            pin_memory=True,
+            num_workers=8
         ),
         dataloader_val=L(DataLoader)(
             dataset=example_multiview_dataset_waymo,
             sampler=L(get_sampler)(dataset=example_multiview_dataset_waymo),
             batch_size=1,
             drop_last=True,
+            pin_memory=True,
+            num_workers=8
         ),
     )
 )

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -56,12 +56,16 @@ dataloader_train = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset),
     batch_size=1,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 dataloader_val = L(DataLoader)(
     dataset=example_video_dataset,
     sampler=L(get_sampler)(dataset=example_video_dataset),
     batch_size=1,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 
 

--- a/cosmos_predict1/diffusion/training/config/video2world_action/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world_action/experiment.py
@@ -86,12 +86,16 @@ dataloader_train = L(DataLoader)(
     sampler=L(get_sampler)(dataset=bridge_train_dataset),
     batch_size=8,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 dataloader_val = L(DataLoader)(
     dataset=bridge_val_dataset,
     sampler=L(get_sampler)(dataset=bridge_val_dataset),
     batch_size=1,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 
 

--- a/cosmos_predict1/diffusion/training/config/video2world_instruction/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world_instruction/experiment.py
@@ -86,12 +86,16 @@ dataloader_train = L(DataLoader)(
     sampler=L(get_sampler)(dataset=bridge_train_dataset),
     batch_size=1,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 dataloader_val = L(DataLoader)(
     dataset=bridge_val_dataset,
     sampler=L(get_sampler)(dataset=bridge_val_dataset),
     batch_size=1,
     drop_last=True,
+    pin_memory=True,
+    num_workers=8
 )
 
 

--- a/cosmos_predict1/diffusion/training/config/video2world_multiview/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world_multiview/experiment.py
@@ -165,12 +165,16 @@ video2world_multiview_7b_example_waymo = LazyDict(
             sampler=L(get_sampler)(dataset=example_multiview_dataset_waymo),
             batch_size=1,
             drop_last=True,
+            pin_memory=True,
+            num_workers=8
         ),
         dataloader_val=L(DataLoader)(
             dataset=example_multiview_dataset_waymo,
             sampler=L(get_sampler)(dataset=example_multiview_dataset_waymo),
             batch_size=1,
             drop_last=True,
+            pin_memory=True,
+            num_workers=8
         ),
     )
 )

--- a/cosmos_predict1/diffusion/training/datasets/dataset_3D.py
+++ b/cosmos_predict1/diffusion/training/datasets/dataset_3D.py
@@ -364,14 +364,14 @@ class Dataset_3D(Dataset):
             if self.load_t5_embeddings:
                 t5_embedding_path = ann_file.replace(".json", ".pickle")
                 with open(t5_embedding_path, "rb") as f:
-                    data["t5_text_embeddings"] = torch.from_numpy(pickle.load(f)[0]).cuda()
+                    data["t5_text_embeddings"] = torch.from_numpy(pickle.load(f)[0])
             else:
-                data["t5_text_embeddings"] = torch.zeros(512, 1024, dtype=torch.bfloat16).cuda()
-            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64).cuda()
+                data["t5_text_embeddings"] = torch.zeros(512, 1024, dtype=torch.bfloat16)
+            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64)
             data["fps"] = 4
-            data["image_size"] = 256 * torch.ones(4).cuda()  # TODO: Does this matter?
+            data["image_size"] = 256 * torch.ones(4)  # TODO: Does this matter?
             data["num_frames"] = self.sequence_length
-            data["padding_mask"] = torch.zeros(1, 256, 256).cuda()
+            data["padding_mask"] = torch.zeros(1, 256, 256)
 
             return data
         except Exception:

--- a/cosmos_predict1/diffusion/training/datasets/dataset_3D_binary.py
+++ b/cosmos_predict1/diffusion/training/datasets/dataset_3D_binary.py
@@ -129,14 +129,14 @@ class Dataset_3DBinary(Dataset_3D):
             if self.load_t5_embeddings:
                 t5_embedding_path = ann_file.replace(".json", ".pickle")
                 with open(t5_embedding_path, "rb") as f:
-                    data["t5_text_embeddings"] = torch.from_numpy(pickle.load(f)[0]).cuda()
+                    data["t5_text_embeddings"] = torch.from_numpy(pickle.load(f)[0])
             else:
-                data["t5_text_embeddings"] = torch.zeros(512, 1024, dtype=torch.bfloat16).cuda()
-            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64).cuda()
+                data["t5_text_embeddings"] = torch.zeros(512, 1024, dtype=torch.bfloat16)
+            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64)
             data["fps"] = 4
-            data["image_size"] = 256 * torch.ones(4).cuda()  # TODO: Does this matter?
+            data["image_size"] = 256 * torch.ones(4)  # TODO: Does this matter?
             data["num_frames"] = self.sequence_length
-            data["padding_mask"] = torch.zeros(1, 256, 256).cuda()
+            data["padding_mask"] = torch.zeros(1, 256, 256)
 
             return data
         except Exception:

--- a/cosmos_predict1/diffusion/training/datasets/dataset_multiview.py
+++ b/cosmos_predict1/diffusion/training/datasets/dataset_multiview.py
@@ -179,12 +179,12 @@ class Dataset(Dataset):
                 "t5_embedding_path": t5_embedding_path,
                 "start_frame_id": str(frame_ids[0]),
             }
-            data["t5_text_embeddings"] = t5_embedding.cuda()
-            data["t5_text_mask"] = torch.ones(512 * len(self.view_keys), dtype=torch.int64).cuda()
+            data["t5_text_embeddings"] = t5_embedding
+            data["t5_text_mask"] = torch.ones(512 * len(self.view_keys), dtype=torch.int64)
             data["fps"] = fps
-            data["image_size"] = torch.tensor([704, 1280, 704, 1280]).cuda()
+            data["image_size"] = torch.tensor([704, 1280, 704, 1280])
             data["num_frames"] = self.sequence_length
-            data["padding_mask"] = torch.zeros(1, 704, 1280).cuda()
+            data["padding_mask"] = torch.zeros(1, 704, 1280)
 
             return data
         except Exception:

--- a/cosmos_predict1/diffusion/training/datasets/dataset_video.py
+++ b/cosmos_predict1/diffusion/training/datasets/dataset_video.py
@@ -163,12 +163,12 @@ class Dataset(Dataset):
             with open(sample["t5_embedding_path"], "rb") as f:
                 t5_embedding = pickle.load(f)[0]
 
-            data["t5_text_embeddings"] = torch.from_numpy(t5_embedding).cuda()
-            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64).cuda()
+            data["t5_text_embeddings"] = torch.from_numpy(t5_embedding)
+            data["t5_text_mask"] = torch.ones(512, dtype=torch.int64)
             data["fps"] = fps
-            data["image_size"] = torch.tensor([704, 1280, 704, 1280]).cuda()
+            data["image_size"] = torch.tensor([704, 1280, 704, 1280])
             data["num_frames"] = self.sequence_length
-            data["padding_mask"] = torch.zeros(1, 704, 1280).cuda()
+            data["padding_mask"] = torch.zeros(1, 704, 1280)
 
             return data
         except Exception:

--- a/cosmos_predict1/utils/trainer.py
+++ b/cosmos_predict1/utils/trainer.py
@@ -154,6 +154,9 @@ class Trainer:
                 with self.training_timer("dataloader_train"):
                     try:
                         data_batch = next(dataloader_train_iter)
+                        for k in data_batch.keys():
+                            if torch.is_tensor(data_batch[k]):
+                                data_batch[k] = data_batch[k].cuda()
                     except StopIteration:
                         break
                 self.callbacks.on_after_dataloading(iteration)


### PR DESCRIPTION
This MR:
- sets `num_workers=8` and `pin_memory=True` for all diffusion training related dataloaders
- moves `CPU -> GPU` data transfer to the training loop, because if it is inside `Dataset` it causes issues with dataloader workers

Without this fix it takes about 3.2s between iterations to get data, with the fix time is less than 50ms. I've tested it on 7B diffusion Text2World.