### PR TITLE
Enable checkpointing of Transformer Blocks in diffusion 7B Text2World fine tuning by default for improved performance

### DIFF
--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -373,6 +373,7 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
+                use_checkpoint=True
             ),
             vae=dict(pixel_chunk_duration=num_frames),
         ),

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -82,7 +82,7 @@ Run the following command to execute an example post-training job with `cosmos_n
 export OUTPUT_ROOT=checkpoints # default value
 torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets
+    -- experiment=text2world_7b_example_cosmos_nemo_assets model.net.use_checkpoint=True
 ```
 
 Optionally, multi-node training can be done with

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -82,7 +82,7 @@ Run the following command to execute an example post-training job with `cosmos_n
 export OUTPUT_ROOT=checkpoints # default value
 torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets model.net.use_checkpoint=True
+    -- experiment=text2world_7b_example_cosmos_nemo_assets
 ```
 
 Optionally, multi-node training can be done with


### PR DESCRIPTION
Without checkpointing the model runs, but suffers from repeated cudaMalloc and cudaFree calls caused by large memory usage. The fix to this issue is reducing memory usage, which I did by setting `use_checkpoint=True` in network config.

With the change `forward+backward` takes about `3.3s`, without this iteration times are highly variable and can take from `3.9s` to `12s`. Test was done on 8xH100 GPUs.

Note that it would probably be better in increase parallelisms in case of multi-node training instead of checkpointing but I haven't tested that yet.