### PR TITLE
Performance improvements for autoregressive model training

### DIFF
--- a/cosmos_predict1/autoregressive/configs/base/dataloader.py
+++ b/cosmos_predict1/autoregressive/configs/base/dataloader.py
@@ -67,4 +67,6 @@ def get_tealrobot_video(
         sampler=L(get_sampler)(dataset=dataset),
         batch_size=batch_size,
         drop_last=True,
+        pin_memory=True,
+        num_workers=8
     )

--- a/cosmos_predict1/autoregressive/configs/experiment/video2video/basic.py
+++ b/cosmos_predict1/autoregressive/configs/experiment/video2video/basic.py
@@ -73,7 +73,7 @@ base_4b_example_tealrobotsmall_tp1: LazyDict = LazyDict(
             distributed_parallelism="ddp",
             callbacks=dict(
                 vid_sampling_tf=dict(
-                    every_n=2,
+                    every_n=500,
                 ),
             ),
         ),
@@ -134,7 +134,7 @@ base_4b_example_tealrobot_tp4: LazyDict = LazyDict(
             distributed_parallelism="ddp",
             callbacks=dict(
                 vid_sampling_tf=dict(
-                    every_n=2,
+                    every_n=500,
                 ),
             ),
         ),
@@ -142,7 +142,7 @@ base_4b_example_tealrobot_tp4: LazyDict = LazyDict(
             load_path="checkpoints/Cosmos-Predict1-4B/model.pt",
             load_training_state=False,
             strict_resume=False,
-            save_iter=10,
+            save_iter=1000,
         ),
         model_parallel=create_model_parallel_config(),
     ),


### PR DESCRIPTION
This MR:

- adds `pin_memory=True` and `num_workers=8` to dataloader in order to remove dataloader waiting time in each iteration
- changes `checkpoint.save_iter` to `1000` for `base_4b_example_tealrobot_tp4` (it is set to `1000` for `base_4b_example_tealrobotsmall_tp1`)
- sets `vid_sampling_tf.every_n` to `500` as by default it was set to `2` and this callback takes similar time to iteration and it doesn't need to be ran every 2 steps