### PR TITLE
14B Text2World performance improvements

### DIFF
--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -443,7 +443,7 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
         model_parallel=dict(
             sequence_parallel=False,
             tensor_model_parallel_size=1,
-            context_parallel_size=8,
+            context_parallel_size=16,
         ),
         model=dict(
             # Use 16x16x32x40 latent shape for training


### PR DESCRIPTION
This MR changes context parallelism for 14B Text2World model from `8` to `16`. With `8` model sufferes from repeated `cudaMalloc` and `cudaFree` caused by large memory usage. This issue persists for 4x8xH100 and 8x8xH100 GPUs. On 8x8xH100 GPUs average iteration time is about `15s` with CP16 it's about `6.4s`, taking into account reduces global batch size speedup is around 1.17x.

I'm not sure whether LR should be adjusted or gradient accumulation enabled.