### PR TITLE
Low-resolution training for 40GB GPUs

### DIFF
--- a/assets/diffusion/loss_examples/text2world_7b_example_cosmos_nemo_assets.svg
+++ b/assets/diffusion/loss_examples/text2world_7b_example_cosmos_nemo_assets.svg
@@ -1,0 +1,1027 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-04-10T10:45:33.921943</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.0, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 57.6 307.584 
+L 57.6 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m419993f62c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m419993f62c" x="57.6" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(54.41875 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 102.24 307.584 
+L 102.24 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m419993f62c" x="102.24" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 250 -->
+      <g transform="translate(92.69625 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 146.88 307.584 
+L 146.88 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m419993f62c" x="146.88" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 500 -->
+      <g transform="translate(137.33625 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 191.52 307.584 
+L 191.52 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m419993f62c" x="191.52" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 750 -->
+      <g transform="translate(181.97625 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 236.16 307.584 
+L 236.16 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m419993f62c" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1000 -->
+      <g transform="translate(223.435 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 280.8 307.584 
+L 280.8 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m419993f62c" x="280.8" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1250 -->
+      <g transform="translate(268.075 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 325.44 307.584 
+L 325.44 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m419993f62c" x="325.44" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1500 -->
+      <g transform="translate(312.715 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 370.08 307.584 
+L 370.08 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m419993f62c" x="370.08" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 1750 -->
+      <g transform="translate(357.355 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 414.72 307.584 
+L 414.72 41.472 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m419993f62c" x="414.72" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2000 -->
+      <g transform="translate(401.995 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- Iterations -->
+     <g transform="translate(212.346719 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(29.492188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(68.701172 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(130.224609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(171.337891 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(232.617188 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(271.826172 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(299.609375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(360.791016 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(424.169922 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_19">
+      <path d="M 57.6 292.434432 
+L 414.72 292.434432 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_20">
+      <defs>
+       <path id="m65c918ccad" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="292.434432" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −3 -->
+      <g transform="translate(35.857813 296.233651) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_21">
+      <path d="M 57.6 253.33625 
+L 414.72 253.33625 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="253.33625" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- −2 -->
+      <g transform="translate(35.857813 257.135469) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_23">
+      <path d="M 57.6 214.238068 
+L 414.72 214.238068 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="214.238068" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- −1 -->
+      <g transform="translate(35.857813 218.037287) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_25">
+      <path d="M 57.6 175.139887 
+L 414.72 175.139887 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="175.139887" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0 -->
+      <g transform="translate(44.2375 178.939105) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_27">
+      <path d="M 57.6 136.041705 
+L 414.72 136.041705 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="136.041705" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1 -->
+      <g transform="translate(44.2375 139.840923) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_29">
+      <path d="M 57.6 96.943523 
+L 414.72 96.943523 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="96.943523" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2 -->
+      <g transform="translate(44.2375 100.742742) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_31">
+      <path d="M 57.6 57.845341 
+L 414.72 57.845341 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m65c918ccad" x="57.6" y="57.845341" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 3 -->
+      <g transform="translate(44.2375 61.64456) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Loss -->
+     <g transform="translate(29.778125 185.495187) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(115.144531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(167.244141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_33">
+    <path d="M 61.1712 101.830796 
+L 62.9568 53.568 
+L 64.7424 112.520239 
+L 66.528 180.597993 
+L 68.3136 202.934784 
+L 70.0992 203.701108 
+L 71.8848 222.178909 
+L 73.6704 180.828672 
+L 75.456 177.661719 
+L 77.2416 178.443683 
+L 79.0272 223.402682 
+L 80.8128 235.92583 
+L 82.5984 234.702057 
+L 84.384 152.384745 
+L 86.1696 216.986671 
+L 87.9552 230.11975 
+L 89.7408 205.992262 
+L 91.5264 236.840727 
+L 93.312 236.840727 
+L 95.0976 209.503279 
+L 96.8832 216.986671 
+L 98.6688 227.984989 
+L 100.4544 232.25842 
+L 102.24 238.674432 
+L 104.0256 241.118068 
+L 105.8112 240.508137 
+L 107.5968 216.071773 
+L 109.3824 235.315898 
+L 111.168 198.047511 
+L 112.9536 197.132614 
+L 114.7392 226.761216 
+L 116.5248 241.423034 
+L 118.3104 241.728 
+L 120.096 199.57625 
+L 121.8816 201.562438 
+L 123.6672 234.397091 
+L 125.4528 244.781568 
+L 127.2384 245.395409 
+L 129.024 238.0645 
+L 130.8096 210.727052 
+L 132.5952 238.0645 
+L 134.3808 240.508137 
+L 136.1664 246.310307 
+L 137.952 215.457932 
+L 139.7376 213.78062 
+L 141.5232 242.951773 
+L 143.3088 245.395409 
+L 145.0944 241.728 
+L 146.88 242.032966 
+L 148.6656 244.476602 
+L 150.4512 215.152966 
+L 152.2368 249.058909 
+L 154.0224 206.754676 
+L 155.808 252.421353 
+L 157.5936 223.707648 
+L 159.3792 204.006074 
+L 161.1648 224.622545 
+L 162.9504 220.040239 
+L 164.736 188.120483 
+L 166.5216 254.556113 
+L 168.3072 150.55104 
+L 170.0928 237.145693 
+L 171.8784 229.509818 
+L 173.664 231.038557 
+L 175.4496 201.409955 
+L 177.2352 241.728 
+L 179.0208 253.946182 
+L 180.8064 235.92583 
+L 182.592 224.012614 
+L 184.3776 227.680023 
+L 186.1632 234.702057 
+L 187.9488 250.587648 
+L 189.7344 241.728 
+L 191.52 249.363875 
+L 193.3056 250.892614 
+L 195.0912 231.343523 
+L 196.8768 222.483875 
+L 198.6624 232.567296 
+L 200.448 254.556113 
+L 202.2336 236.840727 
+L 204.0192 253.031284 
+L 205.8048 242.341841 
+L 207.5904 241.728 
+L 209.376 253.031284 
+L 211.1616 233.177228 
+L 212.9472 248.144012 
+L 214.7328 241.118068 
+L 216.5184 237.759535 
+L 218.304 259.443386 
+L 220.0896 235.620864 
+L 221.8752 255.779887 
+L 223.6608 248.144012 
+L 225.4464 244.781568 
+L 227.232 238.674432 
+L 229.0176 235.315898 
+L 230.8032 226.151284 
+L 232.5888 250.892614 
+L 234.3744 249.668841 
+L 236.16 244.171636 
+L 237.9456 214.543034 
+L 239.7312 243.561705 
+L 241.5168 239.589329 
+L 243.3024 264.330659 
+L 245.088 187.279872 
+L 246.8736 255.169955 
+L 248.6592 247.53408 
+L 250.4448 258.223523 
+L 252.2304 255.169955 
+L 254.016 256.389818 
+L 255.8016 258.223523 
+L 257.5872 239.589329 
+L 259.3728 261.277091 
+L 261.1584 236.840727 
+L 262.944 255.779887 
+L 264.7296 258.833455 
+L 266.5152 229.509818 
+L 268.3008 249.668841 
+L 270.0864 230.428625 
+L 271.872 271.665478 
+L 273.6576 248.144012 
+L 275.4432 269.831773 
+L 277.2288 260.667159 
+L 279.0144 219.125341 
+L 280.8 271.665478 
+L 282.5856 235.92583 
+L 284.3712 255.169955 
+L 286.1568 263.110796 
+L 287.9424 261.277091 
+L 289.728 233.482193 
+L 291.5136 236.230796 
+L 293.2992 171.855639 
+L 295.0848 213.933103 
+L 296.8704 260.667159 
+L 298.656 260.057228 
+L 300.4416 250.892614 
+L 302.2272 260.667159 
+L 304.0128 264.330659 
+L 305.7984 262.500864 
+L 307.584 261.277091 
+L 309.3696 258.223523 
+L 311.1552 255.779887 
+L 312.9408 221.873943 
+L 314.7264 255.169955 
+L 316.512 255.169955 
+L 318.2976 265.554432 
+L 320.0832 249.668841 
+L 321.8688 248.448977 
+L 323.6544 269.217932 
+L 325.44 256.389818 
+L 327.2256 274.719046 
+L 329.0112 214.543034 
+L 330.7968 242.951773 
+L 332.5824 274.719046 
+L 336.1536 216.986671 
+L 337.9392 257.00366 
+L 339.7248 258.223523 
+L 341.5104 240.203171 
+L 343.296 229.509818 
+L 345.0816 246.920239 
+L 346.8672 242.951773 
+L 348.6528 251.807511 
+L 350.4384 256.389818 
+L 352.224 222.792751 
+L 354.0096 242.951773 
+L 355.7952 253.946182 
+L 357.5808 263.720727 
+L 359.3664 271.051636 
+L 361.152 261.890932 
+L 362.9376 233.177228 
+L 364.7232 264.9445 
+L 366.5088 269.831773 
+L 368.2944 230.733591 
+L 371.8656 277.772614 
+L 373.6512 267.998068 
+L 375.4368 252.421353 
+L 377.2224 250.282682 
+L 379.008 273.495273 
+L 380.7936 250.892614 
+L 382.5792 208.435898 
+L 384.3648 272.275409 
+L 386.1504 265.554432 
+L 387.936 289.380864 
+L 389.7216 258.833455 
+L 391.5072 290.600727 
+L 393.2928 263.720727 
+L 395.0784 264.9445 
+L 396.864 250.892614 
+L 398.6496 289.380864 
+L 400.4352 248.448977 
+L 402.2208 252.726319 
+L 404.0064 233.482193 
+L 405.792 185.829329 
+L 407.5776 278.382545 
+L 409.3632 237.759535 
+L 411.1488 264.9445 
+L 412.9344 257.00366 
+L 414.72 295.488 
+L 414.72 295.488 
+" clip-path="url(#p26e0b2e571)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- Loss vs Iterations -->
+    <g transform="translate(183.932813 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4c"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(53.962891 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(115.144531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(167.244141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(219.34375 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(251.130859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(310.310547 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(362.410156 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(394.197266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(423.689453 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(462.898438 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(524.421875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(565.535156 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(626.814453 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(666.023438 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(693.806641 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(754.988281 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(818.367188 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 353.785625 64.150125 
+L 407.72 64.150125 
+Q 409.72 64.150125 409.72 62.150125 
+L 409.72 48.472 
+Q 409.72 46.472 407.72 46.472 
+L 353.785625 46.472 
+Q 351.785625 46.472 351.785625 48.472 
+L 351.785625 62.150125 
+Q 351.785625 64.150125 353.785625 64.150125 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_34">
+     <path d="M 355.785625 54.570438 
+L 365.785625 54.570438 
+L 375.785625 54.570438 
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_20">
+     <!-- Loss -->
+     <g transform="translate(383.785625 58.070438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(115.144531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(167.244141 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p26e0b2e571">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/cosmos_predict1/diffusion/training/config/base/vae.py
+++ b/cosmos_predict1/diffusion/training/config/base/vae.py
@@ -18,13 +18,6 @@ import omegaconf
 from cosmos_predict1.diffusion.training.module.pretrained_vae import VideoJITTokenizer
 from cosmos_predict1.utils.lazy_config import LazyCall as L
 
-# from cosmos_predict1.diffusion.module.pretrained_vae import (
-#     JointImageVideoSharedJITTokenizer,
-#     VideoJITTokenizer,
-#     JITVAE,
-# )
-
-
 TOKENIZER_OPTIONS = {}
 
 

--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -41,7 +41,8 @@ def get_sampler(dataset):
 
 cs = ConfigStore.instance()
 
-num_frames = 121
+n_length = 15
+num_frames = 8 * n_length + 1  # 121
 
 # HDVILA example
 example_video_dataset_hdvila = L(Dataset)(
@@ -87,27 +88,75 @@ dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     drop_last=True,
 )
 
-example_video_dataset_cosmos_nemo_assets_lowres = L(Dataset)(
+n_length_4gpu_40gb = 2
+num_frames_4gpu_40gb = 8 * n_length_4gpu_40gb + 1  # 17
+example_video_dataset_cosmos_nemo_assets_4gpu_40gb = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
-    num_frames=num_frames,
+    num_frames=num_frames_4gpu_40gb,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+)
+dataloader_val_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+)
+
+n_length_8gpu_40gb = 4
+num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 33
+example_video_dataset_cosmos_nemo_assets_8gpu_40gb = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames_8gpu_40gb,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+)
+dataloader_val_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+)
+
+
+n_length_4gpu_80gb = 15
+num_frames_4gpu_80gb = 8 * n_length_4gpu_80gb + 1  # 121
+example_video_dataset_cosmos_nemo_assets_4gpu_80gb = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames_4gpu_80gb,
     video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering the content aspect ratio.
     start_frame_interval=1,
 )
 
-dataloader_train_cosmos_nemo_assets_lowres = L(DataLoader)(
-    dataset=example_video_dataset_cosmos_nemo_assets_lowres,
-    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_lowres),
+dataloader_train_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb),
     batch_size=1,
     drop_last=True,
 )
-dataloader_val_cosmos_nemo_assets_lowres = L(DataLoader)(
-    dataset=example_video_dataset_cosmos_nemo_assets_lowres,
-    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_lowres),
+dataloader_val_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb),
     batch_size=1,
     drop_last=True,
 )
-
 
 text2world_7b_example_hdvila = LazyDict(
     dict(
@@ -190,6 +239,7 @@ text2world_7b_example_hdvila = LazyDict(
                 rope_t_extrapolation_ratio=2,
             ),
             vae=dict(pixel_chunk_duration=num_frames),
+            conditioner=dict(text=dict(dropout_rate=0.0)),
         ),
         model_obj=L(FSDPDiffusionModel)(
             config=PLACEHOLDER,
@@ -393,6 +443,7 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
                 rope_t_extrapolation_ratio=2,
             ),
             vae=dict(pixel_chunk_duration=num_frames),
+            conditioner=dict(text=dict(dropout_rate=0.0)),
         ),
         model_obj=L(FSDPDiffusionModel)(
             config=PLACEHOLDER,
@@ -411,7 +462,7 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
     )
 )
 
-text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
+text2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
     dict(
         defaults=[
             {"override /net": "faditv2_7b"},
@@ -424,7 +475,218 @@ text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
         job=dict(
             project="posttraining",
             group="diffusion_text2world",
-            name="text2world_7b_example_cosmos_nemo_assets_lowres",
+            name="text2world_7b_example_cosmos_nemo_assets_4gpu_40gb",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Text2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+            async_saving=False,  # set to False to save memory
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+                # 24,  # Latent height dim
+                # 24,  # Latent width dim
+                # 12,  # Latent height dim
+                # 12,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=False,
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=True,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=dict(
+                in_channels=16,
+                extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+                use_memory_save=False,
+            ),
+            vae=dict(
+                pixel_chunk_duration=num_frames_4gpu_40gb,
+                spatial_resolution="384",
+            ),
+            conditioner=dict(text=dict(dropout_rate=0.0)),
+        ),
+        model_obj=L(FSDPDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps~(when resume from 310000)
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_4gpu_40gb,
+        dataloader_val=dataloader_val_cosmos_nemo_assets_4gpu_40gb,
+    )
+)
+
+
+text2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            {"override /conditioner": "add_fps_image_size_padding_mask"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_text2world",
+            name="text2world_7b_example_cosmos_nemo_assets_8gpu_40gb",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Text2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+            async_saving=False,  # set to False to save memory
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=False,
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=True,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=dict(
+                in_channels=16,
+                extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+                use_memory_save=False,
+            ),
+            vae=dict(
+                pixel_chunk_duration=num_frames_8gpu_40gb,
+                spatial_resolution="384",
+            ),
+            conditioner=dict(text=dict(dropout_rate=0.0)),
+        ),
+        model_obj=L(FSDPDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps~(when resume from 310000)
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_8gpu_40gb,
+        dataloader_val=dataloader_val_cosmos_nemo_assets_8gpu_40gb,
+    )
+)
+
+text2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            {"override /conditioner": "add_fps_image_size_padding_mask"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_text2world",
+            name="text2world_7b_example_cosmos_nemo_assets_4gpu_80gb",
         ),
         optimizer=dict(
             lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
@@ -460,7 +722,7 @@ text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
         model_parallel=dict(
             sequence_parallel=False,
             tensor_model_parallel_size=1,
-            context_parallel_size=8,
+            context_parallel_size=4,
         ),
         model=dict(
             latent_shape=[
@@ -488,8 +750,13 @@ text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
+                use_memory_save=False,
             ),
-            vae=dict(pixel_chunk_duration=num_frames),
+            vae=dict(
+                pixel_chunk_duration=num_frames_4gpu_80gb,
+                spatial_resolution="384",
+            ),
+            conditioner=dict(text=dict(dropout_rate=0.0)),
         ),
         model_obj=L(FSDPDiffusionModel)(
             config=PLACEHOLDER,
@@ -503,8 +770,8 @@ text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
             f_max=[1.0],
             f_min=[1.0],
         ),
-        dataloader_train=dataloader_train_cosmos_nemo_assets_lowres,
-        dataloader_val=dataloader_val_cosmos_nemo_assets_lowres,
+        dataloader_train=dataloader_train_cosmos_nemo_assets_4gpu_80gb,
+        dataloader_val=dataloader_val_cosmos_nemo_assets_4gpu_80gb,
     )
 )
 
@@ -615,14 +882,16 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
 )
 
 
-def register_experiments(cs):
+def register_experiments(cs: ConfigStore) -> None:
     # Register the experiments
     for _item in [
         text2world_7b_example_hdvila,
         text2world_14b_example_hdvila,
         text2world_7b_example_cosmos_nemo_assets,
         text2world_14b_example_cosmos_nemo_assets,
-        text2world_7b_example_cosmos_nemo_assets_lowres,
+        text2world_7b_example_cosmos_nemo_assets_4gpu_80gb,
+        text2world_7b_example_cosmos_nemo_assets_8gpu_40gb,
+        text2world_7b_example_cosmos_nemo_assets_4gpu_40gb,
     ]:
         experiment_name = _item["job"]["name"]
         log.info(f"Registering experiment: {experiment_name}")

--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -87,6 +87,27 @@ dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     drop_last=True,
 )
 
+example_video_dataset_cosmos_nemo_assets_lowres = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering the content aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_lowres = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_lowres,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_lowres),
+    batch_size=1,
+    drop_last=True,
+)
+dataloader_val_cosmos_nemo_assets_lowres = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_lowres,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_lowres),
+    batch_size=1,
+    drop_last=True,
+)
+
 
 text2world_7b_example_hdvila = LazyDict(
     dict(
@@ -141,7 +162,6 @@ text2world_7b_example_hdvila = LazyDict(
             context_parallel_size=8,
         ),
         model=dict(
-            # Use 16x16x32x40 latent shape for training
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
@@ -241,7 +261,6 @@ text2world_14b_example_hdvila = LazyDict(
             context_parallel_size=8,
         ),
         model=dict(
-            # Use 16x16x32x40 latent shape for training
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
@@ -347,7 +366,6 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
             context_parallel_size=8,
         ),
         model=dict(
-            # Use 16x16x32x40 latent shape for training
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
@@ -390,6 +408,103 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
         ),
         dataloader_train=dataloader_train_cosmos_nemo_assets,
         dataloader_val=dataloader_val_cosmos_nemo_assets,
+    )
+)
+
+text2world_7b_example_cosmos_nemo_assets_lowres = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            {"override /conditioner": "add_fps_image_size_padding_mask"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_text2world",
+            name="text2world_7b_example_cosmos_nemo_assets_lowres",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Text2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=8,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=True,
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=False,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=dict(
+                in_channels=16,
+                extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+            ),
+            vae=dict(pixel_chunk_duration=num_frames),
+        ),
+        model_obj=L(FSDPDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps~(when resume from 310000)
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_lowres,
+        dataloader_val=dataloader_val_cosmos_nemo_assets_lowres,
     )
 )
 
@@ -446,7 +561,6 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
             context_parallel_size=8,
         ),
         model=dict(
-            # Use 16x16x32x40 latent shape for training
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
@@ -508,6 +622,7 @@ def register_experiments(cs):
         text2world_14b_example_hdvila,
         text2world_7b_example_cosmos_nemo_assets,
         text2world_14b_example_cosmos_nemo_assets,
+        text2world_7b_example_cosmos_nemo_assets_lowres,
     ]:
         experiment_name = _item["job"]["name"]
         log.info(f"Registering experiment: {experiment_name}")

--- a/cosmos_predict1/diffusion/training/config/text2world/registry.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/registry.py
@@ -155,28 +155,16 @@ def register_scheduler(cs):
 def register_configs():
     cs = ConfigStore.instance()
 
-    # register_training_and_val_data(cs)
-
     register_optimizer(cs)
     register_scheduler(cs)
 
     register_net(cs)
     register_conditioner(cs)
     register_vae(cs)
-    # register_tokenizer(cs)
 
     register_ema(cs)
-    # register_fsdp(cs)
-
-    # register_callbacks(cs)
-    # register_callback_lvg(cs)
 
     register_checkpoint_credential(cs)
     register_checkpointer(cs)
 
     register_experiments(cs)
-
-    # Register exra data
-    # register_training_and_val_3d_data(cs)
-
-    # register_vae_lvg(cs)

--- a/cosmos_predict1/utils/config.py
+++ b/cosmos_predict1/utils/config.py
@@ -242,6 +242,7 @@ class CheckpointConfig:
     # Whether to use the local filesystem for broadcasting checkpoint data (used for Tensor Parallel Checkpointer).
     broadcast_via_filesystem: bool = False
     load_ema_to_reg: bool = False
+    async_saving: bool = True
 
 
 @make_freezable

--- a/cosmos_predict1/utils/trainer.py
+++ b/cosmos_predict1/utils/trainer.py
@@ -182,7 +182,10 @@ class Trainer:
                 iteration += 1
                 # Save checkpoint.
                 if iteration % self.config.checkpoint.save_iter == 0:
-                    self.checkpointer.save(model, optimizer, scheduler, grad_scaler, iteration=iteration)
+                    async_saving = getattr(self.config.checkpoint, "async_saving", True)
+                    self.checkpointer.save(
+                        model, optimizer, scheduler, grad_scaler, iteration=iteration, async_saving=async_saving
+                    )
                 self.callbacks.on_training_step_end(model, data_batch, output_batch, loss, iteration=iteration)
                 # Validation.
                 if self.config.trainer.run_validation and iteration % self.config.trainer.validation_iter == 0:
@@ -193,7 +196,10 @@ class Trainer:
                 break
         log.success("Done with training.")
         if iteration % self.config.checkpoint.save_iter != 0:
-            self.checkpointer.save(model, optimizer, scheduler, grad_scaler, iteration=iteration)
+            async_saving = getattr(self.config.checkpoint, "async_saving", True)
+            self.checkpointer.save(
+                model, optimizer, scheduler, grad_scaler, iteration=iteration, async_saving=async_saving
+            )
         self.callbacks.on_train_end(model, iteration=iteration)
         self.checkpointer.finalize()
         distributed.barrier()

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -85,6 +85,20 @@ torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
     -- experiment=text2world_7b_example_cosmos_nemo_assets
 ```
 
+Here's an example running log on a single node (8 x H100 GPUs).
+```bash
+[04-03 09:04:40|INFO|cosmos_predict1/utils/trainer.py:144:train] Starting training...
+[04-03 09:07:39|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 20 : iter_speed 7.82 seconds per iteration | Loss: 1.8906
+[04-03 09:08:58|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 30 : iter_speed 7.93 seconds per iteration | Loss: 3.2656
+[04-03 09:10:16|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 40 : iter_speed 7.81 seconds per iteration | Loss: 1.7812
+[04-03 09:11:35|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 50 : iter_speed 7.91 seconds per iteration | Loss: 0.3477
+[04-03 09:12:54|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 60 : iter_speed 7.90 seconds per iteration | Loss: -0.4023
+[04-03 09:14:14|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 70 : iter_speed 7.91 seconds per iteration | Loss: -0.4414
+[04-03 09:15:35|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 80 : iter_speed 8.15 seconds per iteration | Loss: -1.1172
+[04-03 09:16:52|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 90 : iter_speed 7.72 seconds per iteration | Loss: 0.1377 
+Training:   5%|████▉                                                                                                   | 94/2000 [12:44<4:10:00,  7.87s/it]
+```
+
 Optionally, multi-node training can be done with
 ```bash
 # 4-node training example.
@@ -92,6 +106,20 @@ torchrun --nproc_per_node=8 --nnodes=4 --rdzv_id 123 --rdzv_backend c10d --rdzv_
     -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
     -- experiment=text2world_7b_example_cosmos_nemo_assets
+```
+
+Here's an example running log on 4 nodes (8 x H100 GPUs x 4 nodes).
+```bash
+[04-03 09:54:04|INFO|cosmos_predict1/utils/trainer.py:144:train] Starting training...
+[04-03 09:56:39|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 20 : iter_speed 6.85 seconds per iteration | Loss: 1.8672
+[04-03 09:57:47|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 30 : iter_speed 6.79 seconds per iteration | Loss: 2.5000
+[04-03 09:58:56|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 40 : iter_speed 6.86 seconds per iteration | Loss: 1.3281
+[04-03 10:00:04|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 50 : iter_speed 6.85 seconds per iteration | Loss: -0.1289
+[04-03 10:01:12|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 60 : iter_speed 6.82 seconds per iteration | Loss: -0.9336
+[04-03 10:02:21|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 70 : iter_speed 6.83 seconds per iteration | Loss: -1.0000
+[04-03 10:03:30|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 80 : iter_speed 6.91 seconds per iteration | Loss: -1.3359
+[04-03 10:04:38|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 90 : iter_speed 6.87 seconds per iteration | Loss: -0.4297
+Training:   5%|████▊                                                                                                   | 92/2000 [10:48<3:38:34,  6.87s/it]
 ```
 
 
@@ -151,6 +179,34 @@ checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_
 ├── iter_{NUMBER}_ema_model.pt
 ```
 
+* (Optional) Low-resolution training 
+
+3. Download the Cosmos Tokenize model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-predict1-67c9d1b97678dbf7669c89a7):
+```bash
+python3 -m scripts.download_tokenizer_checkpoints --tokenizer_types CV4x8x8-360p
+```
+
+Run the following command to execute an example post-training job with `cosmos_nemo_assets` data at 384x384 resolution.
+```bash
+export OUTPUT_ROOT=checkpoints # default value
+torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
+    --config=cosmos_predict1/diffusion/training/config/config.py \
+    -- experiment=text2world_7b_example_cosmos_nemo_assets_lowres
+```
+
+Here's an example running log on a single node (8 x H100 GPUs).
+```bash
+[04-03 09:41:50|INFO|cosmos_predict1/utils/trainer.py:144:train] Starting training...
+[04-03 09:43:11|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 20 : iter_speed 2.89 seconds per iteration | Loss: 2.3906
+[04-03 09:43:39|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 30 : iter_speed 2.76 seconds per iteration | Loss: 3.9688
+[04-03 09:44:07|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 40 : iter_speed 2.85 seconds per iteration | Loss: 2.3281
+[04-03 09:44:36|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 50 : iter_speed 2.84 seconds per iteration | Loss: 0.3906
+[04-03 09:45:04|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 60 : iter_speed 2.85 seconds per iteration | Loss: -0.3418
+[04-03 09:45:32|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 70 : iter_speed 2.78 seconds per iteration | Loss: -0.3086
+[04-03 09:46:00|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 80 : iter_speed 2.82 seconds per iteration | Loss: -1.1641
+[04-03 09:46:28|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 90 : iter_speed 2.80 seconds per iteration | Loss: 0.7461
+Training:   5%|████▋                                                                                                   | 91/2000 [04:40<1:31:22,  2.87s/it]
+```
 
 ##### Cosmos-Predict1-14B-Text2World
 

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -99,6 +99,10 @@ Here's an example running log on a single node (8 x H100 GPUs).
 Training:   5%|████▉                                                                                                   | 94/2000 [12:44<4:10:00,  7.87s/it]
 ```
 
+Example loss curve:  
+![Image](../assets/diffusion/loss_examples/text2world_7b_example_cosmos_nemo_assets.svg)
+
+
 Optionally, multi-node training can be done with
 ```bash
 # 4-node training example.
@@ -121,9 +125,6 @@ Here's an example running log on 4 nodes (8 x H100 GPUs x 4 nodes).
 [04-03 10:04:38|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 90 : iter_speed 6.87 seconds per iteration | Loss: -0.4297
 Training:   5%|████▊                                                                                                   | 92/2000 [10:48<3:38:34,  6.87s/it]
 ```
-
-Example loss curve:  
-![Image](../assets/diffusion/loss_examples/text2world_7b_example_cosmos_nemo_assets.svg)
 
 The model will be post-trained using the above cosmos_nemo_assets dataset.
 See the config `text2world_7b_example_cosmos_nemo_assets` defined in `cosmos_predict1/diffusion/training/config/text2world/experiment.py` to understand how the dataloader is determined.

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -122,6 +122,8 @@ Here's an example running log on 4 nodes (8 x H100 GPUs x 4 nodes).
 Training:   5%|████▊                                                                                                   | 92/2000 [10:48<3:38:34,  6.87s/it]
 ```
 
+Example loss curve:  
+![Image](../assets/diffusion/loss_examples/text2world_7b_example_cosmos_nemo_assets.svg)
 
 The model will be post-trained using the above cosmos_nemo_assets dataset.
 See the config `text2world_7b_example_cosmos_nemo_assets` defined in `cosmos_predict1/diffusion/training/config/text2world/experiment.py` to understand how the dataloader is determined.
@@ -181,31 +183,31 @@ checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_
 
 * (Optional) Low-resolution training 
 
-3. Download the Cosmos Tokenize model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-predict1-67c9d1b97678dbf7669c89a7):
-```bash
-python3 -m scripts.download_tokenizer_checkpoints --tokenizer_types CV4x8x8-360p
-```
+To run with 4 GPUs with H100/A100 80GB, run experiment `text2world_7b_example_cosmos_nemo_assets_4gpu_80gb`.
+It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 121 frames.
 
-Run the following command to execute an example post-training job with `cosmos_nemo_assets` data at 384x384 resolution.
 ```bash
-export OUTPUT_ROOT=checkpoints # default value
 torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets_lowres
+    -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_80gb
 ```
 
-Here's an example running log on a single node (8 x H100 GPUs).
+To run with 8 GPUs with A100 40GB, run experiment `text2world_7b_example_cosmos_nemo_assets_8gpu_40gb`.
+It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 33 frames.
+
 ```bash
-[04-03 09:41:50|INFO|cosmos_predict1/utils/trainer.py:144:train] Starting training...
-[04-03 09:43:11|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 20 : iter_speed 2.89 seconds per iteration | Loss: 2.3906
-[04-03 09:43:39|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 30 : iter_speed 2.76 seconds per iteration | Loss: 3.9688
-[04-03 09:44:07|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 40 : iter_speed 2.85 seconds per iteration | Loss: 2.3281
-[04-03 09:44:36|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 50 : iter_speed 2.84 seconds per iteration | Loss: 0.3906
-[04-03 09:45:04|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 60 : iter_speed 2.85 seconds per iteration | Loss: -0.3418
-[04-03 09:45:32|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 70 : iter_speed 2.78 seconds per iteration | Loss: -0.3086
-[04-03 09:46:00|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 80 : iter_speed 2.82 seconds per iteration | Loss: -1.1641
-[04-03 09:46:28|INFO|cosmos_predict1/diffusion/training/callbacks/iter_speed.py:80:every_n_impl] 90 : iter_speed 2.80 seconds per iteration | Loss: 0.7461
-Training:   5%|████▋                                                                                                   | 91/2000 [04:40<1:31:22,  2.87s/it]
+torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
+    --config=cosmos_predict1/diffusion/training/config/config.py \
+    -- experiment=text2world_7b_example_cosmos_nemo_assets_8gpu_40gb
+```
+
+To run with 4 GPUs with A100 40GB, run experiment `text2world_7b_example_cosmos_nemo_assets_4gpu_40gb`.
+It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 17 frames.
+
+```bash
+torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
+    --config=cosmos_predict1/diffusion/training/config/config.py \
+    -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_40gb
 ```
 
 ##### Cosmos-Predict1-14B-Text2World


### PR DESCRIPTION
Low-resolution training configs added
* `text2world_7b_example_cosmos_nemo_assets_4gpu_80gb`
  * 384x384 resolution, 121 frames.
* `text2world_7b_example_cosmos_nemo_assets_8gpu_40gb`
  * 384x384 resolution, 33 frames, no ema.
* `text2world_7b_example_cosmos_nemo_assets_4gpu_40gb`
  * 384x384 resolution, 17 frames, no ema.

Several training log examples & loss curve plot are added.

For those configs, `FSDPCheckpointer` saves checkpoints in the main thread instead of saving from a separate thread to save peak memory. The default value is `True` which preserves the previous async behavior.

```python
        checkpoint=dict(
            async_saving=False,  # set to False to save memory
        ),
```