### PR TITLE
Fix dataloading bottleneck for 4x80GB, 4x40GB and 8x40GB

### DIFF
--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -111,12 +111,16 @@ dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 dataloader_val_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 
 n_length_8gpu_40gb = 4
@@ -134,12 +138,16 @@ dataloader_train_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 dataloader_val_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb,
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 
 
@@ -158,12 +166,16 @@ dataloader_train_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 dataloader_val_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb,
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb),
     batch_size=1,
     drop_last=True,
+    num_workers=8,
+    pin_memory=True
 )
 
 text2world_7b_example_hdvila = LazyDict(

--- a/examples/post-training_diffusion_text2world.md
+++ b/examples/post-training_diffusion_text2world.md
@@ -188,7 +188,7 @@ To run with 4 GPUs with H100/A100 80GB, run experiment `text2world_7b_example_co
 It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 121 frames.
 
 ```bash
-torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
+torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
     -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_80gb
 ```
@@ -206,7 +206,7 @@ To run with 4 GPUs with A100 40GB, run experiment `text2world_7b_example_cosmos_
 It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 17 frames.
 
 ```bash
-torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
+torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
     -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_40gb
 ```


### PR DESCRIPTION
This MR sets `num_workers=8` and `pin_memory=True` for dataloaders used in 4x80GB, 4x40GB and 8x40GB experiments. With this fix dataloading bottleneck is removed. Also fixes torchrun argument in README `--nproc_per_node=8` for configs that use 4 GPUs.