### PR TITLE
Positional embedding types set to correct values.

### DIFF
--- a/cosmos_predict1/diffusion/config/base/net.py
+++ b/cosmos_predict1/diffusion/config/base/net.py
@@ -76,5 +76,5 @@ FADITV2_Multiview_Config: LazyDict = L(MultiviewGeneralDIT)(
     rope_h_extrapolation_ratio=1.0,
     rope_w_extrapolation_ratio=1.0,
     rope_t_extrapolation_ratio=1.0,
-    extra_per_block_abs_pos_emb_type="sincos",
+    extra_per_block_abs_pos_emb_type="learnable",
 )

--- a/cosmos_predict1/diffusion/config/base/net.py
+++ b/cosmos_predict1/diffusion/config/base/net.py
@@ -72,9 +72,7 @@ FADITV2_Multiview_Config: LazyDict = L(MultiviewGeneralDIT)(
     n_views=6,
     view_condition_dim=6,
     add_repeat_frame_embedding=True,
-    extra_per_block_abs_pos_emb=True,
     rope_h_extrapolation_ratio=1.0,
     rope_w_extrapolation_ratio=1.0,
     rope_t_extrapolation_ratio=1.0,
-    extra_per_block_abs_pos_emb_type="learnable",
 )

--- a/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-text2world.py
+++ b/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-text2world.py
@@ -38,8 +38,6 @@ Cosmos_Predict1_Text2World_7B: LazyDict = LazyDict(
                 160,
             ],
             net=dict(
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1.0,
                 rope_w_extrapolation_ratio=1.0,
                 rope_t_extrapolation_ratio=2.0,
@@ -69,8 +67,6 @@ Cosmos_Predict1_Text2World_14B: LazyDict = LazyDict(
                 160,
             ],
             net=dict(
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,

--- a/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-text2world.py
+++ b/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-text2world.py
@@ -24,7 +24,6 @@ Cosmos_Predict1_Text2World_7B: LazyDict = LazyDict(
             {"override /net": "faditv2_7b"},
             {"override /conditioner": "add_fps_image_size_padding_mask"},
             {"override /tokenizer": "cosmos_diffusion_tokenizer_res720_comp8x8x8_t121_ver092624"},
-
             "_self_",
         ],
         job=dict(
@@ -40,10 +39,10 @@ Cosmos_Predict1_Text2World_7B: LazyDict = LazyDict(
             ],
             net=dict(
                 extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1.0,
                 rope_w_extrapolation_ratio=1.0,
                 rope_t_extrapolation_ratio=2.0,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
         ),
     )
@@ -71,13 +70,13 @@ Cosmos_Predict1_Text2World_14B: LazyDict = LazyDict(
             ],
             net=dict(
                 extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,
                 extra_h_extrapolation_ratio=2.0,
                 extra_t_extrapolation_ratio=2.0,
                 extra_w_extrapolation_ratio=2.0,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
         ),
     )
@@ -116,7 +115,7 @@ Cosmos_Predict1_Text2World_7B_Post_trained_lora: LazyDict = LazyDict(
         ),
         model=dict(
             peft_control=get_fa_ca_qv_lora_config(first_nblocks=27, rank=8, scale=1),
-        )
+        ),
     )
 )
 

--- a/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
+++ b/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
@@ -37,8 +37,6 @@ Cosmos_Predict1_Video2World_7B: LazyDict = LazyDict(
             ],
             conditioner=dict(video_cond_bool=dict()),
             net=L(VideoExtendGeneralDIT)(
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1.0,
                 rope_w_extrapolation_ratio=1.0,
                 rope_t_extrapolation_ratio=2.0,
@@ -66,8 +64,6 @@ Cosmos_Predict1_Video2World_14B: LazyDict = LazyDict(
             ],
             conditioner=dict(video_cond_bool=dict()),
             net=L(VideoExtendGeneralDIT)(
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,

--- a/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
+++ b/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
@@ -38,10 +38,10 @@ Cosmos_Predict1_Video2World_7B: LazyDict = LazyDict(
             conditioner=dict(video_cond_bool=dict()),
             net=L(VideoExtendGeneralDIT)(
                 extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1.0,
                 rope_w_extrapolation_ratio=1.0,
                 rope_t_extrapolation_ratio=2.0,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
         ),
         job=dict(group="Video2World", name="Cosmos_Predict1_Video2World_7B"),
@@ -67,13 +67,13 @@ Cosmos_Predict1_Video2World_14B: LazyDict = LazyDict(
             conditioner=dict(video_cond_bool=dict()),
             net=L(VideoExtendGeneralDIT)(
                 extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,
                 extra_h_extrapolation_ratio=2.0,
                 extra_t_extrapolation_ratio=2.0,
                 extra_w_extrapolation_ratio=2.0,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
         ),
         job=dict(group="Video2World", name="Cosmos_Predict1_Video2World_14B"),
@@ -112,7 +112,7 @@ Cosmos_Predict1_Video2World_7B_Post_trained_lora: LazyDict = LazyDict(
         ),
         model=dict(
             peft_control=get_fa_ca_qv_lora_config(first_nblocks=27, rank=8, scale=1),
-        )
+        ),
     )
 )
 

--- a/cosmos_predict1/diffusion/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/networks/general_dit.py
@@ -111,7 +111,7 @@ class GeneralDIT(nn.Module):
         rope_h_extrapolation_ratio: float = 1.0,
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
-        extra_per_block_abs_pos_emb: bool = False,
+        extra_per_block_abs_pos_emb: bool = True,
         extra_per_block_abs_pos_emb_type: str = "sincos",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,

--- a/cosmos_predict1/diffusion/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/networks/general_dit.py
@@ -112,7 +112,7 @@ class GeneralDIT(nn.Module):
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
         extra_per_block_abs_pos_emb: bool = True,
-        extra_per_block_abs_pos_emb_type: str = "sincos",
+        extra_per_block_abs_pos_emb_type: str = "learnable",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,
         extra_t_extrapolation_ratio: float = 1.0,

--- a/cosmos_predict1/diffusion/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/networks/general_dit.py
@@ -258,6 +258,8 @@ class GeneralDIT(nn.Module):
             **kwargs,
         )
 
+        assert self.extra_per_block_abs_pos_emb is True, "extra_per_block_abs_pos_emb must be True"
+
         if self.extra_per_block_abs_pos_emb:
             assert self.extra_per_block_abs_pos_emb_type in [
                 "learnable",
@@ -265,9 +267,7 @@ class GeneralDIT(nn.Module):
             kwargs["h_extrapolation_ratio"] = self.extra_h_extrapolation_ratio
             kwargs["w_extrapolation_ratio"] = self.extra_w_extrapolation_ratio
             kwargs["t_extrapolation_ratio"] = self.extra_t_extrapolation_ratio
-            self.extra_pos_embedder = LearnablePosEmbAxis(
-                **kwargs,
-            )
+            self.extra_pos_embedder = LearnablePosEmbAxis(**kwargs)
 
     def prepare_embedded_sequence(
         self,

--- a/cosmos_predict1/diffusion/networks/general_dit_multiview.py
+++ b/cosmos_predict1/diffusion/networks/general_dit_multiview.py
@@ -62,7 +62,7 @@ class MultiviewGeneralDIT(GeneralDIT):
         rope_h_extrapolation_ratio: float = 1.0,
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
-        extra_per_block_abs_pos_emb: bool = False,
+        extra_per_block_abs_pos_emb: bool = True,
         extra_per_block_abs_pos_emb_type: str = "sincos",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,

--- a/cosmos_predict1/diffusion/networks/general_dit_multiview.py
+++ b/cosmos_predict1/diffusion/networks/general_dit_multiview.py
@@ -63,7 +63,7 @@ class MultiviewGeneralDIT(GeneralDIT):
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
         extra_per_block_abs_pos_emb: bool = True,
-        extra_per_block_abs_pos_emb_type: str = "sincos",
+        extra_per_block_abs_pos_emb_type: str = "learnable",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,
         extra_t_extrapolation_ratio: float = 1.0,

--- a/cosmos_predict1/diffusion/networks/general_dit_multiview.py
+++ b/cosmos_predict1/diffusion/networks/general_dit_multiview.py
@@ -63,7 +63,7 @@ class MultiviewGeneralDIT(GeneralDIT):
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
         extra_per_block_abs_pos_emb: bool = True,
-        extra_per_block_abs_pos_emb_type: str = "learnable",
+        extra_per_block_abs_pos_emb_type: str = "sincos",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,
         extra_t_extrapolation_ratio: float = 1.0,
@@ -196,12 +196,13 @@ class MultiviewGeneralDIT(GeneralDIT):
         )
 
         if self.extra_per_block_abs_pos_emb:
+            assert self.extra_per_block_abs_pos_emb_type in [
+                "sincos",
+            ], f"Unknown extra_per_block_abs_pos_emb_type {self.extra_per_block_abs_pos_emb_type}"
             kwargs["h_extrapolation_ratio"] = self.extra_h_extrapolation_ratio
             kwargs["w_extrapolation_ratio"] = self.extra_w_extrapolation_ratio
             kwargs["t_extrapolation_ratio"] = self.extra_t_extrapolation_ratio
-            self.extra_pos_embedder = MultiviewSinCosPosEmbAxis(
-                **kwargs,
-            )
+            self.extra_pos_embedder = MultiviewSinCosPosEmbAxis(**kwargs)
 
     def forward_before_blocks(
         self,

--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -30,6 +30,7 @@ from cosmos_predict1.utils.lazy_config import LazyCall as L
 from cosmos_predict1.utils.lazy_config import LazyDict
 from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 
+
 def get_sampler(dataset):
     return DistributedSampler(
         dataset,
@@ -60,7 +61,7 @@ dataloader_train_hdvila = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_hdvila = L(DataLoader)(
     dataset=example_video_dataset_hdvila,
@@ -68,7 +69,7 @@ dataloader_val_hdvila = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 # Cosmos-NeMo-Assets example
@@ -94,7 +95,7 @@ dataloader_train_cosmos_nemo_assets = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets,
@@ -102,7 +103,7 @@ dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 dataloader_train_cosmos_nemo_assets_480_848 = L(DataLoader)(
@@ -111,7 +112,7 @@ dataloader_train_cosmos_nemo_assets_480_848 = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_cosmos_nemo_assets_480_848 = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_480_848,
@@ -119,7 +120,7 @@ dataloader_val_cosmos_nemo_assets_480_848 = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 n_length_4gpu_40gb = 2
@@ -130,7 +131,7 @@ example_video_dataset_cosmos_nemo_assets_4gpu_40gb = L(Dataset)(
     num_frames=num_frames_4gpu_40gb,
     video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
     start_frame_interval=1,
-)   
+)
 
 dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
@@ -138,7 +139,7 @@ dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
@@ -146,7 +147,7 @@ dataloader_val_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 n_length_8gpu_40gb = 4
@@ -165,7 +166,7 @@ dataloader_train_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb,
@@ -173,7 +174,7 @@ dataloader_val_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 
@@ -193,7 +194,7 @@ dataloader_train_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 dataloader_val_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb,
@@ -201,7 +202,7 @@ dataloader_val_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     num_workers=8,
-    pin_memory=True
+    pin_memory=True,
 )
 
 text2world_7b_example_hdvila = LazyDict(
@@ -487,6 +488,7 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
+                use_checkpoint=True,
             ),
             vae=dict(pixel_chunk_duration=num_frames),
             conditioner=dict(text=dict(dropout_rate=0.0)),
@@ -897,6 +899,7 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
             net=dict(
                 in_channels=16,
                 extra_per_block_abs_pos_emb=True,
+                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,
@@ -904,7 +907,6 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
                 extra_t_extrapolation_ratio=2.0,
                 extra_w_extrapolation_ratio=2.0,
                 use_memory_save=True,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
             adjust_video_noise=True,
             vae=dict(pixel_chunk_duration=num_frames),
@@ -1014,6 +1016,7 @@ text2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
         dataloader_val=dataloader_val_cosmos_nemo_assets_480_848,
     )
 )
+
 
 def register_experiments(cs: ConfigStore) -> None:
     # Register the experiments

--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -279,8 +279,6 @@ text2world_7b_example_hdvila = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
@@ -380,7 +378,6 @@ text2world_14b_example_hdvila = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,
@@ -388,7 +385,6 @@ text2world_14b_example_hdvila = LazyDict(
                 extra_t_extrapolation_ratio=2.0,
                 extra_w_extrapolation_ratio=2.0,
                 use_memory_save=True,
-                extra_per_block_abs_pos_emb_type="learnable",
             ),
             adjust_video_noise=True,
             vae=dict(pixel_chunk_duration=num_frames),
@@ -483,8 +479,6 @@ text2world_7b_example_cosmos_nemo_assets = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
@@ -587,8 +581,6 @@ text2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
@@ -691,8 +683,6 @@ text2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
@@ -793,8 +783,6 @@ text2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,
@@ -898,8 +886,6 @@ text2world_14b_example_cosmos_nemo_assets = LazyDict(
             ),
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=2.0,
                 rope_t_extrapolation_ratio=2.0,
                 rope_w_extrapolation_ratio=2.0,
@@ -997,8 +983,6 @@ text2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
             fsdp_enabled=False,
             net=dict(
                 in_channels=16,
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -31,6 +31,7 @@ from cosmos_predict1.utils.lazy_config import LazyDict
 from cosmos_predict1.diffusion.training.models.model_peft import PEFTExtendDiffusionModel
 from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 
+
 def get_sampler(dataset):
     return DistributedSampler(
         dataset,
@@ -58,7 +59,7 @@ dataloader_train = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     pin_memory=True,
-    num_workers=8
+    num_workers=8,
 )
 dataloader_val = L(DataLoader)(
     dataset=example_video_dataset,
@@ -66,7 +67,7 @@ dataloader_val = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     pin_memory=True,
-    num_workers=8
+    num_workers=8,
 )
 
 example_video_dataset_cosmos_nemo_assets = L(Dataset)(
@@ -83,7 +84,7 @@ dataloader_train_cosmos_nemo_assets = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     pin_memory=True,
-    num_workers=8
+    num_workers=8,
 )
 
 dataloader_val_cosmos_nemo_assets = L(DataLoader)(
@@ -92,7 +93,7 @@ dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     batch_size=1,
     drop_last=True,
     pin_memory=True,
-    num_workers=8
+    num_workers=8,
 )
 
 
@@ -274,8 +275,6 @@ video2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
             ),
             fsdp_enabled=False,
             net=L(VideoExtendGeneralDIT)(
-                extra_per_block_abs_pos_emb=True,
-                extra_per_block_abs_pos_emb_type="learnable",
                 rope_h_extrapolation_ratio=1,
                 rope_w_extrapolation_ratio=1,
                 rope_t_extrapolation_ratio=2,

--- a/cosmos_predict1/diffusion/training/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/training/networks/general_dit.py
@@ -179,7 +179,7 @@ class GeneralDIT(nn.Module):
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
         extra_per_block_abs_pos_emb: bool = True,
-        extra_per_block_abs_pos_emb_type: str = "sincos",
+        extra_per_block_abs_pos_emb_type: str = "learnable",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,
         extra_t_extrapolation_ratio: float = 1.0,
@@ -441,7 +441,6 @@ class GeneralDIT(nn.Module):
 
         if self.extra_per_block_abs_pos_emb:
             assert self.extra_per_block_abs_pos_emb_type in [
-                "sincos",
                 "learnable",
             ], f"Unknown extra_per_block_abs_pos_emb_type {self.extra_per_block_abs_pos_emb_type}"
             kwargs["h_extrapolation_ratio"] = self.extra_h_extrapolation_ratio

--- a/cosmos_predict1/diffusion/training/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/training/networks/general_dit.py
@@ -178,7 +178,7 @@ class GeneralDIT(nn.Module):
         rope_h_extrapolation_ratio: float = 1.0,
         rope_w_extrapolation_ratio: float = 1.0,
         rope_t_extrapolation_ratio: float = 1.0,
-        extra_per_block_abs_pos_emb: bool = False,
+        extra_per_block_abs_pos_emb: bool = True,
         extra_per_block_abs_pos_emb_type: str = "sincos",
         extra_h_extrapolation_ratio: float = 1.0,
         extra_w_extrapolation_ratio: float = 1.0,

--- a/cosmos_predict1/diffusion/training/networks/general_dit.py
+++ b/cosmos_predict1/diffusion/training/networks/general_dit.py
@@ -439,6 +439,8 @@ class GeneralDIT(nn.Module):
             **kwargs,
         )
 
+        assert self.extra_per_block_abs_pos_emb is True, "extra_per_block_abs_pos_emb must be True"
+
         if self.extra_per_block_abs_pos_emb:
             assert self.extra_per_block_abs_pos_emb_type in [
                 "learnable",
@@ -446,14 +448,7 @@ class GeneralDIT(nn.Module):
             kwargs["h_extrapolation_ratio"] = self.extra_h_extrapolation_ratio
             kwargs["w_extrapolation_ratio"] = self.extra_w_extrapolation_ratio
             kwargs["t_extrapolation_ratio"] = self.extra_t_extrapolation_ratio
-            if self.extra_per_block_abs_pos_emb_type == "sincos":
-                self.extra_pos_embedder = SinCosPosEmbAxis(
-                    **kwargs,
-                )
-            elif self.extra_per_block_abs_pos_emb_type == "learnable":
-                self.extra_pos_embedder = LearnablePosEmbAxis(
-                    **kwargs,
-                )
+            self.extra_pos_embedder = LearnablePosEmbAxis(**kwargs)
 
     def prepare_embedded_sequence(
         self,

--- a/cosmos_predict1/diffusion/training/networks/general_dit_multiview.py
+++ b/cosmos_predict1/diffusion/training/networks/general_dit_multiview.py
@@ -154,13 +154,16 @@ class MultiviewGeneralDIT(GeneralDIT):
             **kwargs,
         )
 
+        assert self.extra_per_block_abs_pos_emb is True, "extra_per_block_abs_pos_emb must be True"
+
         if self.extra_per_block_abs_pos_emb:
+            assert self.extra_per_block_abs_pos_emb_type in [
+                "sincos",
+            ], f"Unknown extra_per_block_abs_pos_emb_type {self.extra_per_block_abs_pos_emb_type}"
             kwargs["h_extrapolation_ratio"] = self.extra_h_extrapolation_ratio
             kwargs["w_extrapolation_ratio"] = self.extra_w_extrapolation_ratio
             kwargs["t_extrapolation_ratio"] = self.extra_t_extrapolation_ratio
-            self.extra_pos_embedder = MultiviewSinCosPosEmbAxis(
-                **kwargs,
-            )
+            self.extra_pos_embedder = MultiviewSinCosPosEmbAxis(**kwargs)
 
     def forward_before_blocks(
         self,


### PR DESCRIPTION
The arguments for network classes are set as below.

* `GeneralDiT`, 
```python
extra_per_block_abs_pos_emb=True
extra_per_block_abs_pos_emb_type="learnable"
```

* `MultiViewGeneralDiT`, 
```python
extra_per_block_abs_pos_emb=True
extra_per_block_abs_pos_emb_type="sincos"
```

`assert` prevents them from being modified by config overwrites so that the correct values are always used for both training & inference.

The config input for the above variables are removed from all example configs in the repo.