### PR TITLE
fix a bug when using EMA in multi-nodes training

### DIFF
--- a/cosmos_predict1/utils/fsdp_checkpointer.py
+++ b/cosmos_predict1/utils/fsdp_checkpointer.py
@@ -351,6 +351,7 @@ class FSDPCheckpointer:
         if not os.path.exists(checkpoint_path):
             if is_raise:
                 raise FileNotFoundError(f"File not found (local): {checkpoint_path}")
+            return False
         return True
 
     def finalize(self) -> None:


### PR DESCRIPTION
When [calling](https://github.com/nvidia-cosmos/cosmos-predict1/blob/f3ab35aa967ebdd01212c093d20a43c76c0eaec4/cosmos_predict1/utils/fsdp_checkpointer.py#L93) `self._check_checkpoint_exists` while loading a checkpoint in multi-nodes training, the bug occurs because the function does not `return False`.
