### PR TITLE
Video2world low-memory post-training & inference support

### DIFF
--- a/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
+++ b/cosmos_predict1/diffusion/config/inference/cosmos-1-diffusion-video2world.py
@@ -16,9 +16,9 @@
 from hydra.core.config_store import ConfigStore
 
 from cosmos_predict1.diffusion.networks.general_dit_video_conditioned import VideoExtendGeneralDIT
+from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 from cosmos_predict1.utils.lazy_config import LazyCall as L
 from cosmos_predict1.utils.lazy_config import LazyDict
-from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 
 Cosmos_Predict1_Video2World_7B: LazyDict = LazyDict(
     dict(
@@ -87,6 +87,73 @@ Cosmos_Predict1_Video2World_7B_Post_trained: LazyDict = LazyDict(
     )
 )
 
+Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_80gb: LazyDict = LazyDict(
+    dict(
+        defaults=[
+            "/experiment/Cosmos_Predict1_Video2World_7B",
+        ],
+        job=dict(
+            name="Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_80gb",
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            tokenizer=dict(
+                video_vae=dict(pixel_chunk_duration=121, spatial_resolution="384"),
+            ),
+        ),
+    )
+)
+
+Cosmos_Predict1_Video2World_7B_Post_trained_8gpu_40gb: LazyDict = LazyDict(
+    dict(
+        defaults=[
+            "/experiment/Cosmos_Predict1_Video2World_7B",
+        ],
+        job=dict(
+            name="Cosmos_Predict1_Video2World_7B_Post_trained_8gpu_40gb",
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            tokenizer=dict(
+                video_vae=dict(pixel_chunk_duration=25, spatial_resolution="384"),
+            ),
+        ),
+    )
+)
+
+Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_40gb: LazyDict = LazyDict(
+    dict(
+        defaults=[
+            "/experiment/Cosmos_Predict1_Video2World_7B",
+        ],
+        job=dict(
+            name="Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_40gb",
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                24,  # Latent height dim
+                24,  # Latent width dim
+            ],
+            tokenizer=dict(
+                # video_vae=dict(pixel_chunk_duration=17, spatial_resolution="384"),
+                video_vae=dict(pixel_chunk_duration=25, spatial_resolution="384"),
+            ),
+        ),
+    )
+)
+
 Cosmos_Predict1_Video2World_14B_Post_trained: LazyDict = LazyDict(
     dict(
         defaults=[
@@ -118,6 +185,9 @@ for _item in [
     Cosmos_Predict1_Video2World_14B,
     Cosmos_Predict1_Video2World_7B_Post_trained,
     Cosmos_Predict1_Video2World_14B_Post_trained,
+    Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_80gb,
+    Cosmos_Predict1_Video2World_7B_Post_trained_8gpu_40gb,
+    Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_40gb,
     Cosmos_Predict1_Video2World_7B_Post_trained_lora,
 ]:
     cs.store(group="experiment", package="_global_", name=_item["job"]["name"], node=_item)

--- a/cosmos_predict1/diffusion/inference/text2world.py
+++ b/cosmos_predict1/diffusion/inference/text2world.py
@@ -41,11 +41,11 @@ def parse_arguments() -> argparse.Namespace:
             "Cosmos-Predict1-7B-Text2World",
             "Cosmos-Predict1-14B-Text2World",
             "Cosmos-Predict1-7B-Text2World_post-trained",
-            "Cosmos-Predict1-14B-Text2World_post-trained",
             "Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb",
             "Cosmos-Predict1-7B-Text2World_post-trained-8gpu_40gb",
             "Cosmos-Predict1-7B-Text2World_post-trained-4gpu_40gb",
             "Cosmos-Predict1-7B-Text2World_post-trained-lora",
+            "Cosmos-Predict1-14B-Text2World_post-trained",
         ],
     )
     parser.add_argument(

--- a/cosmos_predict1/diffusion/inference/video2world.py
+++ b/cosmos_predict1/diffusion/inference/video2world.py
@@ -18,7 +18,12 @@ import os
 
 import torch
 
-from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, check_input_frames, get_input_sizes, validate_args
+from cosmos_predict1.diffusion.inference.inference_utils import (
+    add_common_arguments,
+    check_input_frames,
+    get_input_sizes,
+    validate_args,
+)
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionVideo2WorldGenerationPipeline
 from cosmos_predict1.utils import log, misc
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
@@ -41,8 +46,11 @@ def parse_arguments() -> argparse.Namespace:
             "Cosmos-Predict1-7B-Video2World",
             "Cosmos-Predict1-14B-Video2World",
             "Cosmos-Predict1-7B-Video2World_post-trained",
-            "Cosmos-Predict1-14B-Video2World_post-trained",
+            "Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb",
+            "Cosmos-Predict1-7B-Video2World_post-trained-8gpu_40gb",
+            "Cosmos-Predict1-7B-Video2World_post-trained-4gpu_40gb",
             "Cosmos-Predict1-7B-Video2World_post-trained-lora",
+            "Cosmos-Predict1-14B-Video2World_post-trained",
         ],
     )
     parser.add_argument(

--- a/cosmos_predict1/diffusion/inference/world_generation_pipeline.py
+++ b/cosmos_predict1/diffusion/inference/world_generation_pipeline.py
@@ -31,11 +31,13 @@ from cosmos_predict1.diffusion.inference.inference_utils import (
     load_model_by_config,
     load_network_model,
     load_tokenizer_model,
+    read_video_or_image_into_frames_BCTHW,
 )
 from cosmos_predict1.diffusion.model.model_t2w import DiffusionT2WModel
 from cosmos_predict1.diffusion.model.model_t2w_multiview import DiffusionMultiviewT2WModel
 from cosmos_predict1.diffusion.model.model_v2w import DiffusionV2WModel
 from cosmos_predict1.diffusion.model.model_v2w_multiview import DiffusionMultiviewV2WModel
+from cosmos_predict1.diffusion.model.model_world_interpolator import DiffusionWorldInterpolatorWModel
 from cosmos_predict1.diffusion.prompt_upsampler.text2world_prompt_upsampler_inference import (
     create_prompt_upsampler,
     run_chat_completion,
@@ -47,29 +49,36 @@ from cosmos_predict1.diffusion.prompt_upsampler.video2world_prompt_upsampler_inf
 from cosmos_predict1.diffusion.prompt_upsampler.video2world_prompt_upsampler_inference import (
     run_chat_completion as run_chat_completion_vlm,
 )
+from cosmos_predict1.diffusion.training.utils.inference_long_video import generate_video_from_batch_with_loop
 from cosmos_predict1.utils import log
 from cosmos_predict1.utils.base_world_generation_pipeline import BaseWorldGenerationPipeline
-from cosmos_predict1.diffusion.model.model_world_interpolator import DiffusionWorldInterpolatorWModel
-from cosmos_predict1.diffusion.training.utils.inference_long_video import generate_video_from_batch_with_loop
-from cosmos_predict1.diffusion.inference.inference_utils import read_video_or_image_into_frames_BCTHW
 
 MODEL_NAME_DICT = {
+    # text2world
     "Cosmos-Predict1-7B-Text2World": "Cosmos_Predict1_Text2World_7B",
     "Cosmos-Predict1-14B-Text2World": "Cosmos_Predict1_Text2World_14B",
-    "Cosmos-Predict1-7B-Video2World": "Cosmos_Predict1_Video2World_7B",
-    "Cosmos-Predict1-14B-Video2World": "Cosmos_Predict1_Video2World_14B",
     "Cosmos-Predict1-7B-Text2World_post-trained": "Cosmos_Predict1_Text2World_7B_Post_trained",
     "Cosmos-Predict1-14B-Text2World_post-trained": "Cosmos_Predict1_Text2World_14B_Post_trained",
-    "Cosmos-Predict1-7B-Video2World_post-trained": "Cosmos_Predict1_Video2World_7B_Post_trained",
-    "Cosmos-Predict1-14B-Video2World_post-trained": "Cosmos_Predict1_Video2World_14B_Post_trained",
+    # text2world low-memory
     "Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb": "Cosmos_Predict1_Text2World_7B_Post_trained_4gpu_80gb",
     "Cosmos-Predict1-7B-Text2World_post-trained-8gpu_40gb": "Cosmos_Predict1_Text2World_7B_Post_trained_8gpu_40gb",
     "Cosmos-Predict1-7B-Text2World_post-trained-4gpu_40gb": "Cosmos_Predict1_Text2World_7B_Post_trained_4gpu_40gb",
+    # text2world lora
     "Cosmos-Predict1-7B-Text2World_post-trained-lora": "Cosmos_Predict1_Text2World_7B_Post_trained_lora",
+    # video2world
+    "Cosmos-Predict1-7B-Video2World": "Cosmos_Predict1_Video2World_7B",
+    "Cosmos-Predict1-14B-Video2World": "Cosmos_Predict1_Video2World_14B",
+    "Cosmos-Predict1-7B-Video2World_post-trained": "Cosmos_Predict1_Video2World_7B_Post_trained",
+    "Cosmos-Predict1-14B-Video2World_post-trained": "Cosmos_Predict1_Video2World_14B_Post_trained",
+    # video2world low-memory
+    "Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb": "Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_80gb",
+    "Cosmos-Predict1-7B-Video2World_post-trained-8gpu_40gb": "Cosmos_Predict1_Video2World_7B_Post_trained_8gpu_40gb",
+    "Cosmos-Predict1-7B-Video2World_post-trained-4gpu_40gb": "Cosmos_Predict1_Video2World_7B_Post_trained_4gpu_40gb",
+    # video2world lora
     "Cosmos-Predict1-7B-Video2World_post-trained-lora": "Cosmos_Predict1_Video2World_7B_Post_trained_lora",
     "Cosmos-Predict1-7B-Text2World-Sample-AV-Multiview": "Cosmos_Predict1_Text2World_7B_Multiview",
     "Cosmos-Predict1-7B-Video2World-Sample-AV-Multiview": "Cosmos_Predict1_Video2World_7B_Multiview",
-    "Cosmos-Predict1-7B-WorldInterpolator": "Cosmos_Predict1_WorldInterpolator_7B"
+    "Cosmos-Predict1-7B-WorldInterpolator": "Cosmos_Predict1_WorldInterpolator_7B",
 }
 
 
@@ -1361,9 +1370,7 @@ class DiffusionWorldInterpolatorGenerationPipeline(DiffusionVideo2WorldGeneratio
         video_tensor = torch.cat(video_output, dim=1)  # Shape: (C, total_num_frames, H, W)
 
         # Convert to NumPy array for guardrail: [T, H, W, C], uint8, [0, 255]
-        video_np = (
-            video_tensor.permute(1, 2, 3, 0) * 255
-        ).to(torch.uint8).cpu().numpy()  # Shape: (T, H, W, C)
+        video_np = (video_tensor.permute(1, 2, 3, 0) * 255).to(torch.uint8).cpu().numpy()  # Shape: (T, H, W, C)
 
         if self.offload_network:
             self._offload_network()

--- a/cosmos_predict1/diffusion/training/config/text2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/text2world/experiment.py
@@ -98,7 +98,7 @@ dataloader_val_cosmos_nemo_assets = L(DataLoader)(
     pin_memory=True,
 )
 
-# Cosmos-NeMo-Assets 480x848 example
+# Cosmos-NeMo-Assets 480x848 example for lora
 example_video_dataset_cosmos_nemo_assets_480_848 = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
@@ -666,7 +666,7 @@ text2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
             ],
             loss_reduce="mean",
             ema=dict(
-                enabled=False,
+                enabled=False,  # turn off to save memory
             ),
             fsdp_enabled=True,
             fsdp=dict(
@@ -767,7 +767,7 @@ text2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
             ],
             loss_reduce="mean",
             ema=dict(
-                enabled=False,
+                enabled=False,  # turn off to save memory
             ),
             fsdp_enabled=True,
             fsdp=dict(

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -160,7 +160,7 @@ video2world_7b_example_hdvila = LazyDict(
         model_parallel=dict(
             sequence_parallel=False,
             tensor_model_parallel_size=1,
-            context_parallel_size=8,
+            context_parallel_size=1,
         ),
         model=dict(
             latent_shape=[
@@ -176,7 +176,7 @@ video2world_7b_example_hdvila = LazyDict(
             fsdp_enabled=True,
             fsdp=dict(
                 policy="block",
-                checkpoint=False,
+                checkpoint=True,
                 min_num_params=1024,
                 sharding_group_size=32,
                 sharding_strategy="hybrid",
@@ -273,7 +273,7 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
         model_parallel=dict(
             sequence_parallel=False,
             tensor_model_parallel_size=1,
-            context_parallel_size=8,
+            context_parallel_size=1,
         ),
         model=dict(
             latent_shape=[
@@ -289,7 +289,7 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
             fsdp_enabled=True,
             fsdp=dict(
                 policy="block",
-                checkpoint=False,
+                checkpoint=True,
                 min_num_params=1024,
                 sharding_group_size=32,
                 sharding_strategy="hybrid",
@@ -428,8 +428,8 @@ video2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
         scheduler=dict(
             warm_up_steps=[0],
         ),
-        dataloader_train=dataloader_train_cosmos_nemo_assets,
-        dataloader_val=dataloader_val_cosmos_nemo_assets,
+        dataloader_train=dataloader_train_cosmos_nemo_assets_480_848,
+        dataloader_val=dataloader_val_cosmos_nemo_assets_480_848,
     )
 )
 

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -103,8 +103,8 @@ dataloader_train_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
     pin_memory=True,
 )
 
-n_length_8gpu_40gb = 4
-num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 33
+n_length_8gpu_40gb = 3
+num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 25
 example_video_dataset_cosmos_nemo_assets_8gpu_40gb = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
@@ -122,13 +122,13 @@ dataloader_train_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
     pin_memory=True,
 )
 
-n_length_4gpu_40gb = 2
-num_frames_4gpu_40gb = 8 * n_length_4gpu_40gb + 1  # 17
+n_length_4gpu_40gb = 3
+num_frames_4gpu_40gb = 8 * n_length_4gpu_40gb + 1  # 25
 example_video_dataset_cosmos_nemo_assets_4gpu_40gb = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
     num_frames=num_frames_4gpu_40gb,
-    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    video_size=(192, 192),  # a low-res example for lower VRAM utilization without considering aspect ratio.
     start_frame_interval=1,
 )
 
@@ -137,7 +137,7 @@ dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
     batch_size=1,
     drop_last=True,
-    num_workers=8,
+    num_workers=0,
     pin_memory=True,
 )
 
@@ -668,8 +668,8 @@ video2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
-                48,  # Latent height dim
-                48,  # Latent width dim
+                24,  # Latent height dim
+                24,  # Latent width dim
             ],
             loss_reduce="mean",
             ema=dict(
@@ -706,7 +706,7 @@ video2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
             ),
             vae=dict(
                 pixel_chunk_duration=num_frames_4gpu_40gb,
-                spatial_resolution="384",
+                spatial_resolution="192",
             ),
         ),
         model_obj=L(FSDPExtendDiffusionModel)(

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -83,7 +83,7 @@ dataloader_train_cosmos_nemo_assets = L(DataLoader)(
     num_workers=8,
 )
 
-example_video_dataset_cosmos_nemo_assets = L(Dataset)(
+example_video_dataset_cosmos_nemo_assets_480_848 = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
     num_frames=num_frames,
@@ -91,18 +91,18 @@ example_video_dataset_cosmos_nemo_assets = L(Dataset)(
     start_frame_interval=1,
 )
 
-dataloader_train_cosmos_nemo_assets = L(DataLoader)(
-    dataset=example_video_dataset_cosmos_nemo_assets,
-    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
+dataloader_train_cosmos_nemo_assets_480_848 = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_480_848,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_480_848),
     batch_size=1,
     drop_last=True,
     pin_memory=True,
     num_workers=8,
 )
 
-dataloader_val_cosmos_nemo_assets = L(DataLoader)(
-    dataset=example_video_dataset_cosmos_nemo_assets,
-    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets),
+dataloader_val_cosmos_nemo_assets_480_848 = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_480_848,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_480_848),
     batch_size=1,
     drop_last=True,
     pin_memory=True,

--- a/cosmos_predict1/diffusion/training/config/video2world/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/video2world/experiment.py
@@ -21,15 +21,15 @@ from cosmos_predict1.diffusion.training.callbacks.iter_speed import IterSpeed
 from cosmos_predict1.diffusion.training.callbacks.low_precision import LowPrecisionCallback
 from cosmos_predict1.diffusion.training.datasets.dataset_video import Dataset
 from cosmos_predict1.diffusion.training.models.extend_model import FSDPExtendDiffusionModel
+from cosmos_predict1.diffusion.training.models.model_peft import PEFTExtendDiffusionModel
 from cosmos_predict1.diffusion.training.networks.general_dit_lvg import VideoExtendGeneralDIT
+from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 from cosmos_predict1.utils import log
 from cosmos_predict1.utils.callback import ProgressBarCallback
 from cosmos_predict1.utils.callbacks.grad_clip import GradClip
 from cosmos_predict1.utils.lazy_config import PLACEHOLDER
 from cosmos_predict1.utils.lazy_config import LazyCall as L
 from cosmos_predict1.utils.lazy_config import LazyDict
-from cosmos_predict1.diffusion.training.models.model_peft import PEFTExtendDiffusionModel
-from cosmos_predict1.diffusion.training.utils.peft.lora_config import get_fa_ca_qv_lora_config
 
 
 def get_sampler(dataset):
@@ -83,6 +83,65 @@ dataloader_train_cosmos_nemo_assets = L(DataLoader)(
     num_workers=8,
 )
 
+# Cosmos-NeMo-Assets examples with more affordable GPUs setup (4 GPUs or 40GB VRAM)
+n_length_4gpu_80gb = 15
+num_frames_4gpu_80gb = 8 * n_length_4gpu_80gb + 1  # 121
+example_video_dataset_cosmos_nemo_assets_4gpu_80gb = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames_4gpu_80gb,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering the content aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_80gb),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+
+n_length_8gpu_40gb = 4
+num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 33
+example_video_dataset_cosmos_nemo_assets_8gpu_40gb = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames_8gpu_40gb,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_8gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+
+n_length_4gpu_40gb = 2
+num_frames_4gpu_40gb = 8 * n_length_4gpu_40gb + 1  # 17
+example_video_dataset_cosmos_nemo_assets_4gpu_40gb = L(Dataset)(
+    dataset_dir="datasets/cosmos_nemo_assets",
+    sequence_interval=1,
+    num_frames=num_frames_4gpu_40gb,
+    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    start_frame_interval=1,
+)
+
+dataloader_train_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
+    dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb,
+    sampler=L(get_sampler)(dataset=example_video_dataset_cosmos_nemo_assets_4gpu_40gb),
+    batch_size=1,
+    drop_last=True,
+    num_workers=8,
+    pin_memory=True,
+)
+
+# Cosmos-NeMo-Assets 480x848 example for lora
 example_video_dataset_cosmos_nemo_assets_480_848 = L(Dataset)(
     dataset_dir="datasets/cosmos_nemo_assets",
     sequence_interval=1,
@@ -132,7 +191,6 @@ video2world_7b_example_hdvila = LazyDict(
         ),
         checkpoint=dict(
             save_iter=200,
-            # save_iter=1,
             broadcast_via_filesystem=False,
             load_path="checkpoints/Cosmos-Predict1-7B-Video2World/model.pt",
             load_training_state=False,
@@ -141,7 +199,6 @@ video2world_7b_example_hdvila = LazyDict(
         ),
         trainer=dict(
             max_iter=2000,
-            # max_iter=2,
             distributed_parallelism="fsdp",
             logging_iter=200,
             callbacks=dict(
@@ -164,10 +221,10 @@ video2world_7b_example_hdvila = LazyDict(
         ),
         model=dict(
             latent_shape=[
-                16,
-                16,
-                88,
-                160,
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                88,  # Latent height dim
+                160,  # Latent width dim
             ],
             loss_reduce="mean",
             ema=dict(
@@ -208,7 +265,7 @@ video2world_7b_example_hdvila = LazyDict(
             config=PLACEHOLDER,
             fsdp_checkpointer=PLACEHOLDER,
         ),
-        # warming up for first 2500 steps~(when resume from 310000)
+        # warming up for first 2500 steps
         scheduler=dict(
             warm_up_steps=[2500],
             cycle_lengths=[10000000000000],
@@ -237,15 +294,13 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
             name="video2world_7b_example_cosmos_nemo_assets",
         ),
         optimizer=dict(
-            # lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
-            lr=0.0,
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
             weight_decay=0.1,
             betas=[0.9, 0.99],
             eps=1e-10,
         ),
         checkpoint=dict(
             save_iter=200,
-            # save_iter=1,
             broadcast_via_filesystem=False,
             load_path="checkpoints/Cosmos-Predict1-7B-Video2World/model.pt",
             load_training_state=False,
@@ -254,7 +309,6 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
         ),
         trainer=dict(
             max_iter=2000,
-            # max_iter=2,
             distributed_parallelism="fsdp",
             logging_iter=200,
             callbacks=dict(
@@ -277,10 +331,10 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
         ),
         model=dict(
             latent_shape=[
-                16,
-                16,
-                88,
-                160,
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                88,  # Latent height dim
+                160,  # Latent width dim
             ],
             loss_reduce="mean",
             ema=dict(
@@ -321,7 +375,7 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
             config=PLACEHOLDER,
             fsdp_checkpointer=PLACEHOLDER,
         ),
-        # warming up for first 2500 steps~(when resume from 310000)
+        # warming up for first 2500 steps
         scheduler=dict(
             warm_up_steps=[2500],
             cycle_lengths=[10000000000000],
@@ -330,6 +384,344 @@ video2world_7b_example_cosmos_nemo_assets = LazyDict(
             f_min=[1.0],
         ),
         dataloader_train=dataloader_train_cosmos_nemo_assets,
+    )
+)
+
+video2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /conditioner": "video_cond"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_4gpu_80gb",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Video2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=True,
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=True,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=L(VideoExtendGeneralDIT)(
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+            ),
+            adjust_video_noise=True,
+            conditioner=dict(
+                video_cond_bool=dict(
+                    condition_location="first_random_n",
+                    cfg_unconditional_type="zero_condition_region_condition_mask",
+                    apply_corruption_to_condition_region="noise_with_sigma",
+                    condition_on_augment_sigma=False,
+                    dropout_rate=0.0,  # No dropout
+                    first_random_n_num_condition_t_max=2,
+                    normalize_condition_latent=False,
+                    # Let the augment sigma mostly fall in the range of 0 to 0.3
+                    augment_sigma_sample_p_mean=-3.0,
+                    augment_sigma_sample_p_std=2.0,
+                    augment_sigma_sample_multiplier=1.0,
+                )
+            ),
+            vae=dict(
+                pixel_chunk_duration=num_frames_4gpu_80gb,
+                spatial_resolution="384",
+            ),
+        ),
+        model_obj=L(FSDPExtendDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_4gpu_80gb,
+    )
+)
+
+video2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /conditioner": "video_cond"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_8gpu_40gb",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Video2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+            async_saving=False,  # set to False to save memory
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=False,  # turn off to save memory
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=True,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=L(VideoExtendGeneralDIT)(
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+            ),
+            adjust_video_noise=True,
+            conditioner=dict(
+                video_cond_bool=dict(
+                    condition_location="first_random_n",
+                    cfg_unconditional_type="zero_condition_region_condition_mask",
+                    apply_corruption_to_condition_region="noise_with_sigma",
+                    condition_on_augment_sigma=False,
+                    dropout_rate=0.0,  # No dropout
+                    first_random_n_num_condition_t_max=2,
+                    normalize_condition_latent=False,
+                    # Let the augment sigma mostly fall in the range of 0 to 0.3
+                    augment_sigma_sample_p_mean=-3.0,
+                    augment_sigma_sample_p_std=2.0,
+                    augment_sigma_sample_multiplier=1.0,
+                )
+            ),
+            vae=dict(
+                pixel_chunk_duration=num_frames_8gpu_40gb,
+                spatial_resolution="384",
+            ),
+        ),
+        model_obj=L(FSDPExtendDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_8gpu_40gb,
+    )
+)
+
+video2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
+    dict(
+        defaults=[
+            {"override /net": "faditv2_7b"},
+            {"override /conditioner": "video_cond"},
+            {"override /ckpt_klass": "fsdp"},
+            {"override /checkpoint": "local"},
+            {"override /vae": "cosmos_diffusion_tokenizer_comp8x8x8"},
+            "_self_",
+        ],
+        job=dict(
+            project="posttraining",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_4gpu_40gb",
+        ),
+        optimizer=dict(
+            lr=2 ** (-14.3),  # 2**(-14.3) approx 5e-5
+            weight_decay=0.1,
+            betas=[0.9, 0.99],
+            eps=1e-10,
+        ),
+        checkpoint=dict(
+            save_iter=200,
+            broadcast_via_filesystem=False,
+            load_path="checkpoints/Cosmos-Predict1-7B-Video2World/model.pt",
+            load_training_state=False,
+            strict_resume=False,
+            keys_not_to_resume=[],
+            async_saving=False,  # set to False to save memory
+        ),
+        trainer=dict(
+            max_iter=2000,
+            distributed_parallelism="fsdp",
+            logging_iter=200,
+            callbacks=dict(
+                grad_clip=L(GradClip)(
+                    model_key="model",
+                    fsdp_enabled=True,
+                ),
+                low_prec=L(LowPrecisionCallback)(config=PLACEHOLDER, trainer=PLACEHOLDER, update_iter=1),
+                iter_speed=L(IterSpeed)(
+                    every_n=10,
+                    hit_thres=0,
+                ),
+                progress_bar=L(ProgressBarCallback)(),
+            ),
+        ),
+        model_parallel=dict(
+            sequence_parallel=False,
+            tensor_model_parallel_size=1,
+            context_parallel_size=1,
+        ),
+        model=dict(
+            latent_shape=[
+                16,  # Latent channel dim
+                16,  # Latent temporal dim
+                48,  # Latent height dim
+                48,  # Latent width dim
+            ],
+            loss_reduce="mean",
+            ema=dict(
+                enabled=False,  # turn off to save memory
+            ),
+            fsdp_enabled=True,
+            fsdp=dict(
+                policy="block",
+                checkpoint=True,
+                min_num_params=1024,
+                sharding_group_size=32,
+                sharding_strategy="hybrid",
+            ),
+            net=L(VideoExtendGeneralDIT)(
+                rope_h_extrapolation_ratio=1,
+                rope_w_extrapolation_ratio=1,
+                rope_t_extrapolation_ratio=2,
+            ),
+            adjust_video_noise=True,
+            conditioner=dict(
+                video_cond_bool=dict(
+                    condition_location="first_random_n",
+                    cfg_unconditional_type="zero_condition_region_condition_mask",
+                    apply_corruption_to_condition_region="noise_with_sigma",
+                    condition_on_augment_sigma=False,
+                    dropout_rate=0.0,  # No dropout
+                    first_random_n_num_condition_t_max=2,
+                    normalize_condition_latent=False,
+                    # Let the augment sigma mostly fall in the range of 0 to 0.3
+                    augment_sigma_sample_p_mean=-3.0,
+                    augment_sigma_sample_p_std=2.0,
+                    augment_sigma_sample_multiplier=1.0,
+                )
+            ),
+            vae=dict(
+                pixel_chunk_duration=num_frames_4gpu_40gb,
+                spatial_resolution="384",
+            ),
+        ),
+        model_obj=L(FSDPExtendDiffusionModel)(
+            config=PLACEHOLDER,
+            fsdp_checkpointer=PLACEHOLDER,
+        ),
+        # warming up for first 2500 steps
+        scheduler=dict(
+            warm_up_steps=[2500],
+            cycle_lengths=[10000000000000],
+            f_start=[1.0e-6],
+            f_max=[1.0],
+            f_min=[1.0],
+        ),
+        dataloader_train=dataloader_train_cosmos_nemo_assets_4gpu_40gb,
     )
 )
 
@@ -361,7 +753,7 @@ video2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
             load_training_state=False,
             strict_resume=False,
             keys_not_to_resume=[],
-            async_saving=False,
+            async_saving=False,  # set to False to save memory
         ),
         trainer=dict(
             max_iter=5000,
@@ -395,7 +787,7 @@ video2world_7b_lora_example_cosmos_nemo_assets = LazyDict(
             ],
             loss_reduce="mean",
             ema=dict(
-                enabled=True,
+                enabled=False,  # turn off to save memory
             ),
             fsdp_enabled=False,
             net=L(VideoExtendGeneralDIT)(
@@ -439,6 +831,9 @@ def register_experiments(cs):
     for _item in [
         video2world_7b_example_hdvila,
         video2world_7b_example_cosmos_nemo_assets,
+        video2world_7b_example_cosmos_nemo_assets_4gpu_80gb,
+        video2world_7b_example_cosmos_nemo_assets_8gpu_40gb,
+        video2world_7b_example_cosmos_nemo_assets_4gpu_40gb,
         video2world_7b_lora_example_cosmos_nemo_assets,
     ]:
         experiment_name = _item["job"]["name"]

--- a/examples/post-training_diffusion_video2world.md
+++ b/examples/post-training_diffusion_video2world.md
@@ -187,12 +187,13 @@ The inference can be done with the same interface as described in [examples/infe
 
 The post-trained checkpoint needs to be copied to `checkpoints/Cosmos-Predict1-7B-Video2World_post-trained/model.pt`
 
-For example, if a posttrained checkpoint (ema) with 1000 iterations is to be used,
+For example, if a posttrained checkpoint (ema) with 2000 iterations is to be used,
 ```bash
 # copy checkpoint to the designated location
 mkdir checkpoints/Cosmos-Predict1-7B-Video2World_post-trained/
-cp checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets/checkpoints/iter_000001000_ema_model.pt checkpoints/Cosmos-Predict1-7B-Video2World_post-trained/model.pt
+cp checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets/checkpoints/iter_000002000_ema_model.pt checkpoints/Cosmos-Predict1-7B-Video2World_post-trained/model.pt
 ```
+
 2. Running the Inference
 
 This is the basic example for running inference on the post-trained 7B model with a single image.

--- a/examples/post-training_diffusion_video2world_lowmemory.md
+++ b/examples/post-training_diffusion_video2world_lowmemory.md
@@ -1,4 +1,4 @@
-## Post-training diffusion-based Text2World models
+## Post-training diffusion-based Video2World models
 
 ### Model Support Matrix
 
@@ -6,8 +6,7 @@ We support the following Cosmos Diffusion models for post-training. Review the a
 
 | Model Name                               | Model Status | Compute Requirements for Post-Training |
 |----------------------------------------------|------------------|------------------------------------------|
-| Cosmos-Predict1-7B-Text2World           | **Supported**    | 8 NVIDIA GPUs*                           |
-| Cosmos-Predict1-14B-Text2World          | **Supported**    | 8 NVIDIA GPUs* x 4 nodes                 |
+| Cosmos-Predict1-7B-Video2World           | **Supported**    | 8 NVIDIA GPUs*                           |
 
 **\*** `H100-80GB` or `A100-80GB` GPUs are recommended.
 Optionally, reducing the video resolution and the number of frames can facilitate training with less number (4) of GPUs or with GPUs with lower memory (40GB).
@@ -24,10 +23,11 @@ Please refer to the Post-training section of [INSTALL.md](/INSTALL.md#post-train
    ```bash
    huggingface-cli login
    ```
+3. Accept the [LlamaGuard-7b terms](https://huggingface.co/meta-llama/LlamaGuard-7b)
 
-3. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-predict1-67c9d1b97678dbf7669c89a7):
+4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-predict1-67c9d1b97678dbf7669c89a7):
    ```bash
-   CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_diffusion_checkpoints.py --model_sizes 7B 14B --model_types Text2World
+   CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_diffusion_checkpoints.py --model_sizes 7B --model_types Video2World --checkpoint_dir checkpoints
    ```
 
 ### Examples
@@ -79,16 +79,16 @@ datasets/cosmos_nemo_assets/
 
 * Training with 4 x 80GB GPUs
 
-To run with 4 GPUs with H100/A100 80GB, run experiment `text2world_7b_example_cosmos_nemo_assets_4gpu_80gb`.
+To run with 4 GPUs with H100/A100 80GB, run experiment `video2world_7b_example_cosmos_nemo_assets_4gpu_80gb`.
 It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 121 frames.
 
 ```bash
 torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_80gb
+    -- experiment=video2world_7b_example_cosmos_nemo_assets_4gpu_80gb
 ```
 
-See the config `text2world_7b_example_cosmos_nemo_assets_4gpu_80gb` defined in `cosmos_predict1/diffusion/training/config/text2world/experiment.py` for details.
+See the config `video2world_7b_example_cosmos_nemo_assets_4gpu_80gb` defined in `cosmos_predict1/diffusion/training/config/video2world/experiment.py` for details.
 ```python
 n_length_4gpu_80gb = 15
 num_frames_4gpu_80gb = 8 * n_length_4gpu_80gb + 1  # 121
@@ -108,12 +108,12 @@ dataloader_val_cosmos_nemo_assets_4gpu_80gb = L(DataLoader)(
 )
 ...
 
-text2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
+video2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
     dict(
         job=dict(
             project="posttraining",
-            group="diffusion_text2world",
-            name="text2world_7b_example_cosmos_nemo_assets_4gpu_80gb",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_4gpu_80gb",
         ),
         model=dict(
             latent_shape=[
@@ -136,29 +136,30 @@ text2world_7b_example_cosmos_nemo_assets_4gpu_80gb = LazyDict(
 ```
 
 The checkpoints will be saved to `${OUTPUT_ROOT}/PROJECT/GROUP/NAME`.
-In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_text2world`, `NAME` is `text2world_7b_example_cosmos_nemo_assets_4gpu_80gb`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_video2world`, `NAME` is `video2world_7b_example_cosmos_nemo_assets_4gpu_80gb`.
 
 During the training, the checkpoints will be saved in the below structure.
 ```
-checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_assets_4gpu_80gb/checkpoints/
+checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets_4gpu_80gb/checkpoints/
 ├── iter_{NUMBER}_reg_model.pt
 ├── iter_{NUMBER}_ema_model.pt
 ```
 
+
 * Training with 8 x 40GB GPUs
-To run with 8 GPUs with A100 40GB, run experiment `text2world_7b_example_cosmos_nemo_assets_8gpu_40gb`.
-It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 33 frames.
+To run with 8 GPUs with A100 40GB, run experiment `video2world_7b_example_cosmos_nemo_assets_8gpu_40gb`.
+It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 25 frames.
 
 ```bash
 torchrun --nproc_per_node=8 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets_8gpu_40gb
+    -- experiment=video2world_7b_example_cosmos_nemo_assets_8gpu_40gb
 ```
-See the config `text2world_7b_example_cosmos_nemo_assets_8gpu_40gb` defined in `cosmos_predict1/diffusion/training/config/text2world/experiment.py` for details.
+See the config `video2world_7b_example_cosmos_nemo_assets_8gpu_40gb` defined in `cosmos_predict1/diffusion/training/config/video2world/experiment.py` for details.
 
 ```python
-n_length_8gpu_40gb = 4
-num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 33
+n_length_8gpu_40gb = 3
+num_frames_8gpu_40gb = 8 * n_length_8gpu_40gb + 1  # 25
 example_video_dataset_cosmos_nemo_assets_8gpu_40gb = L(Dataset)(
     num_frames=num_frames_8gpu_40gb,
     video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
@@ -176,12 +177,12 @@ dataloader_val_cosmos_nemo_assets_8gpu_40gb = L(DataLoader)(
 
 ...
 
-text2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
+video2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
     dict(
         job=dict(
             project="posttraining",
-            group="diffusion_text2world",
-            name="text2world_7b_example_cosmos_nemo_assets_8gpu_40gb",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_8gpu_40gb",
         ),
         model=dict(
             latent_shape=[
@@ -206,24 +207,23 @@ text2world_7b_example_cosmos_nemo_assets_8gpu_40gb = LazyDict(
 ...
 ```
 
-
 * Training with 4 x 40GB GPUs
-To run with 4 GPUs with A100 40GB, run experiment `text2world_7b_example_cosmos_nemo_assets_4gpu_40gb`.
-It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 17 frames.
+To run with 4 GPUs with A100 40GB, run experiment `video2world_7b_example_cosmos_nemo_assets_4gpu_40gb`.
+It trains with `cosmos_nemo_assets` data at 384x384 resolution, video length of 25 frames.
 
 ```bash
 torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
     --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=text2world_7b_example_cosmos_nemo_assets_4gpu_40gb
+    -- experiment=video2world_7b_example_cosmos_nemo_assets_4gpu_40gb
 ```
-See the config `text2world_7b_example_cosmos_nemo_assets_4gpu_40gb` defined in `cosmos_predict1/diffusion/training/config/text2world/experiment.py` for details.
+See the config `video2world_7b_example_cosmos_nemo_assets_4gpu_40gb` defined in `cosmos_predict1/diffusion/training/config/video2world/experiment.py` for details.
 
 ```python
 n_length_4gpu_40gb = 2
 num_frames_4gpu_40gb = 8 * n_length_4gpu_40gb + 1  # 17
 example_video_dataset_cosmos_nemo_assets_4gpu_40gb = L(Dataset)(
     num_frames=num_frames_4gpu_40gb,
-    video_size=(384, 384),  # a low-res example for lower VRAM utilization without considering aspect ratio.
+    video_size=(192, 192),  # a low-res example for lower VRAM utilization without considering aspect ratio.
     ...
 )
 
@@ -238,26 +238,26 @@ dataloader_val_cosmos_nemo_assets_4gpu_40gb = L(DataLoader)(
 
 ...
 
-text2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
+video2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
     dict(
         job=dict(
             project="posttraining",
-            group="diffusion_text2world",
-            name="text2world_7b_example_cosmos_nemo_assets_4gpu_40gb",
+            group="diffusion_video2world",
+            name="video2world_7b_example_cosmos_nemo_assets_4gpu_40gb",
         ),
         model=dict(
             latent_shape=[
                 16,  # Latent channel dim
                 16,  # Latent temporal dim
-                48,  # Latent height dim
-                48,  # Latent width dim
+                24,  # Latent height dim
+                24,  # Latent width dim
             ],
             ema=dict(
                 enabled=False,  # turn off to save memory
             ),
             vae=dict(
                 pixel_chunk_duration=num_frames_4gpu_40gb,
-                spatial_resolution="384",
+                spatial_resolution="192",
             ),
             ...
         ),
@@ -268,92 +268,75 @@ text2world_7b_example_cosmos_nemo_assets_4gpu_40gb = LazyDict(
 ...
 ```
 
-
 #### 4. Inference with the Post-trained Model Checkpoint
 
-The inference can be done with the same interface as described in [examples/inference_diffusion_text2world.md](inference_diffusion_text2world.md).
+The inference can be done with the same interface as described in [examples/inference_diffusion_video2world.md](/examples/inference_diffusion_video2world.md).
 
-##### Cosmos-Predict1-7B-Text2World
+##### Cosmos-Predict1-7B-Video2World
 
-1. Copying checkpoint to the designated location
+1. Copying checkpoint to Designated Location
 
-The post-trained checkpoint needs to be copied to `checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb/model.pt`
+The post-trained checkpoint needs to be copied to `checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb/model.pt`
 
-For example, if a post-trained checkpoint (ema) with 2000 iterations is to be used,
+For example, if a posttrained checkpoint (ema) with 2000 iterations is to be used,
 ```bash
 # copy checkpoint to the designated location
-mkdir checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb/
-cp checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_assets_4gpu_80gb/checkpoints/iter_000002000_ema_model.pt checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb/model.pt
+mkdir checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb/
+cp checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets_4gpu_80gb/checkpoints/iter_000002000_ema_model.pt checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb/model.pt
 ```
 
-2. Running the inference
+2. Running the Inference
 
-We will set the prompt with an environment variable first.
-```bash
-PROMPT="A sleek, humanoid robot stands in a vast warehouse filled with neatly stacked cardboard boxes on industrial shelves. \
-The robot's metallic body gleams under the bright, even lighting, highlighting its futuristic design and intricate joints. \
-A glowing blue light emanates from its chest, adding a touch of advanced technology. The background is dominated by rows of boxes, \
-suggesting a highly organized storage system. The floor is lined with wooden pallets, enhancing the industrial setting. \
-The camera remains static, capturing the robot's poised stance amidst the orderly environment, with a shallow depth of \
-field that keeps the focus on the robot while subtly blurring the background for a cinematic effect."
-```
-
+This is the basic example for running inference on the post-trained 7B model with a single image.
 ```bash
 # Run the video generation command with a single gpu
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/text2world.py \
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/video2world.py \
     --checkpoint_dir checkpoints \
-    --diffusion_transformer_dir Cosmos-Predict1-7B-Text2World_post-trained-4gpu_80gb \
-    --num_video_frames 121 \
-    --prompt "${PROMPT}" \
+    --diffusion_transformer_dir Cosmos-Predict1-7B-Video2World_post-trained-4gpu_80gb \
+    --input_image_or_video_path assets/diffusion/video2world_input0.jpg \
+    --num_input_frames 1 \
     --offload_prompt_upsampler \
-    --video_save_name diffusion-text2world-7b-post-trained_4gpu_80gb
+    --video_save_name diffusion-video2world-7b-post-trained-4gpu_80gb
 ```
-
-The output file is located at `outputs/diffusion-text2world-7b-post-trained_4gpu_80gb.mp4`.
 
 * Similarly, 8 GPU 40GB post-trained model inference can be done with
-
 ```bash
 # copy checkpoint to the designated location
-mkdir checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-8gpu_40gb/
-cp checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_assets_8gpu_40gb/checkpoints/iter_000002000_reg_model.pt checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-8gpu_40gb/model.pt
+mkdir checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-8gpu_40gb/
+cp checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets_8gpu_40gb/checkpoints/iter_000002000_reg_model.pt checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-8gpu_40gb/model.pt
 ```
 
 ```bash
 # Run the video generation command with a single gpu
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/text2world.py \
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/video2world.py \
     --checkpoint_dir checkpoints \
-    --diffusion_transformer_dir Cosmos-Predict1-7B-Text2World_post-trained-8gpu_40gb \
-    --num_video_frames 33 \
-    --prompt "${PROMPT}" \
+    --diffusion_transformer_dir Cosmos-Predict1-7B-Video2World_post-trained-8gpu_40gb \
+    --input_image_or_video_path assets/diffusion/video2world_input0.jpg \
+    --num_input_frames 1 \
+    --num_video_frames 25 \
     --offload_text_encoder_model \
     --offload_prompt_upsampler \
     --offload_guardrail_models \
-    --video_save_name diffusion-text2world-7b-post-trained_8gpu_40gb
+    --video_save_name diffusion-video2world-7b-post-trained-8gpu_40gb
 ```
-
-The output file is located at `outputs/diffusion-text2world-7b-post-trained_8gpu_40gb.mp4`.
 
 * Similarly, 4 GPU 40GB post-trained model inference can be done with
-
-Note that we use `reg` model here instead of `ema` as ema is disabled during posttraining to reduce memory consumption.
 ```bash
 # copy checkpoint to the designated location
-mkdir checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-4gpu_40gb/
-cp checkpoints/posttraining/diffusion_text2world/text2world_7b_example_cosmos_nemo_assets_4gpu_40gb/checkpoints/iter_000002000_reg_model.pt checkpoints/Cosmos-Predict1-7B-Text2World_post-trained-4gpu_40gb/model.pt
+mkdir checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-4gpu_40gb/
+cp checkpoints/posttraining/diffusion_video2world/video2world_7b_example_cosmos_nemo_assets_4gpu_40gb/checkpoints/iter_000002000_reg_model.pt checkpoints/Cosmos-Predict1-7B-Video2World_post-trained-4gpu_40gb/model.pt
 ```
 
 ```bash
 # Run the video generation command with a single gpu
-CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/text2world.py \
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/video2world.py \
     --checkpoint_dir checkpoints \
-    --diffusion_transformer_dir Cosmos-Predict1-7B-Text2World_post-trained-4gpu_40gb \
-    --num_video_frames 17 \
-    --prompt "${PROMPT}" \
+    --diffusion_transformer_dir Cosmos-Predict1-7B-Video2World_post-trained-4gpu_40gb \
+    --input_image_or_video_path assets/diffusion/video2world_input0.jpg \
+    --num_input_frames 1 \
+    --num_video_frames 25 \
     --offload_text_encoder_model \
     --offload_prompt_upsampler \
     --offload_guardrail_models \
-    --video_save_name diffusion-text2world-7b-post-trained_4gpu_40gb
+    --video_save_name diffusion-video2world-7b-post-trained-4gpu_40gb
 ```
-
-The output file is located at `outputs/diffusion-text2world-7b-post-trained_4gpu_40gb.mp4`.


### PR DESCRIPTION
* video2world low-memory support
  * `video2world_7b_example_cosmos_nemo_assets_4gpu_80gb`
  * `video2world_7b_example_cosmos_nemo_assets_8gpu_40gb`
  * `video2world_7b_example_cosmos_nemo_assets_4gpu_40gb`'
* dedicated documentation for text2world low-memory post-training is provided.
  * `examples/post-training_diffusion_video2world_lowmemory.md`
* non-async checkpointer now operates in lower peak memory.
* documentation fixes & updates.