### PR TITLE
Cosmos WorldInterpolator Post-training

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Please refer to [INSTALL.md](INSTALL.md) for general instructions on environment
 ### Inference with pre-trained Cosmos-Predict1 models
 * [Inference with diffusion-based Text2World models](/examples/inference_diffusion_text2world.md) **[with multi-GPU support]**
 * [Inference with diffusion-based Video2World models](/examples/inference_diffusion_video2world.md) **[with multi-GPU support]**
+* [Inference with diffusion-based WorldInterpolator models](/examples/inference_diffusion_WorldInterpolator.md) **[with multi-GPU support]**
 * [Inference with autoregressive-based base models](/examples/inference_autoregressive_base.md) **[with multi-GPU support]**
 * [Inference with autoregressive-based Video2World models](/examples/inference_autoregressive_video2world.md) **[with multi-GPU support]**
 * [Inference with tokenizer models](/examples/inference_tokenizer.md)
@@ -66,6 +67,7 @@ Cosmos-Predict1 include the following models
 * [Cosmos-Predict1-14B-Text2World](https://huggingface.co/nvidia/Cosmos-Predict1-14B-Text2World): Text to visual world generation
 * [Cosmos-Predict1-7B-Video2World](https://huggingface.co/nvidia/Cosmos-Predict1-7B-Video2World): Video + Text based future visual world generation
 * [Cosmos-Predict1-14B-Video2World](https://huggingface.co/nvidia/Cosmos-Predict1-14B-Video2World): Video + Text based future visual world generation
+* [Cosmos-Predict1-7B-WorldInterpolator](https://huggingface.co/nvidia/Cosmos-Predict1-7B-WorldInterpolator): Generates a smooth, higher-FPS video segment.
 
 **Autoregressive models**
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Please refer to [INSTALL.md](INSTALL.md) for general instructions on environment
 ### Post-train pre-trained Cosmos-Predict1 models
 * [Post-train diffusion-based Text2World models using custom datasets](/examples/post-training_diffusion_text2world.md) **[with multi-node support]**
 * [Post-train diffusion-based Video2World models using custom datasets](/examples/post-training_diffusion_video2world.md) **[with multi-node support]**
+* [Post-train diffusion-based WorldInterpolator models using custom datasets](/examples/post-training_diffusion_interpolator.md) **[with multi-node support]**
 * [Post-train diffusion-based Text2World models using custom multi-view datasets](/examples/post-training_diffusion_text2world_multiview.md) **[with multi-node support]**
 * [Post-train diffusion-based Video2World models using custom multi-view datasets)](/examples/post-training_diffusion_video2world_multiview.md) **[with multi-node support]**
 * [Post-train autoregressive-based base models using custom datasets](/examples/post-training_autoregressive_base.md) **[with multi-node support]**

--- a/cosmos_predict1/diffusion/inference/world_interpolator.py
+++ b/cosmos_predict1/diffusion/inference/world_interpolator.py
@@ -72,8 +72,6 @@ def parse_arguments() -> argparse.Namespace:
         default=2,
         help="The minimum number of input frames for world_interpolator predictions.",
     )
-    # parser.add_argument("--num_video_frames", type=int, default=118, help="numer of video frames to sample")
-    parser.add_argument("--pixel_chunk_duration", type=int, default=121, help="pixel chunk duration")
     parser.add_argument(
         "--frame_stride",
         type=int,

--- a/cosmos_predict1/diffusion/inference/world_interpolator.py
+++ b/cosmos_predict1/diffusion/inference/world_interpolator.py
@@ -28,7 +28,6 @@ CUDA_VISIBLE_DEVICES=1 python3 -m cosmos_predict1.diffusion.inference.world_inte
 import argparse
 import os
 
-import debugpy
 import torch
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, check_input_frames, validate_args
@@ -36,12 +35,6 @@ from cosmos_predict1.diffusion.inference.world_generation_pipeline import Diffus
 from cosmos_predict1.utils import log, misc
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
-debugpy.listen(("localhost", 5678))
-
-# from cosmos_predict1.utils.visualize.video import save_video
-
-
-# from cosmos_predict1.utils.visualize.video import save_img_or_video
 torch.enable_grad(False)
 
 
@@ -136,9 +129,6 @@ def demo(args):
     misc.set_random_seed(args.seed)
     inference_type = "world_interpolator"
     validate_args(args, inference_type)
-
-    debugpy.wait_for_client()
-    debugpy.breakpoint()
 
     if args.num_gpus > 1:
         from megatron.core import parallel_state

--- a/cosmos_predict1/diffusion/inference/world_interpolator.py
+++ b/cosmos_predict1/diffusion/inference/world_interpolator.py
@@ -28,12 +28,18 @@ CUDA_VISIBLE_DEVICES=1 python3 -m cosmos_predict1.diffusion.inference.world_inte
 import argparse
 import os
 
+import debugpy
 import torch
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, check_input_frames, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionWorldInterpolatorGenerationPipeline
 from cosmos_predict1.utils import log, misc
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
+
+debugpy.listen(("localhost", 5678))
+
+# from cosmos_predict1.utils.visualize.video import save_video
+
 
 # from cosmos_predict1.utils.visualize.video import save_img_or_video
 torch.enable_grad(False)
@@ -130,6 +136,9 @@ def demo(args):
     misc.set_random_seed(args.seed)
     inference_type = "world_interpolator"
     validate_args(args, inference_type)
+
+    debugpy.wait_for_client()
+    debugpy.breakpoint()
 
     if args.num_gpus > 1:
         from megatron.core import parallel_state

--- a/cosmos_predict1/diffusion/training/config/base/model.py
+++ b/cosmos_predict1/diffusion/training/config/base/model.py
@@ -71,7 +71,6 @@ class DefaultModelConfig:
     use_dummy_temporal_dim: bool = False  # Whether to use dummy temporal dimension in data
     adjust_video_noise: bool = False  # whether or not adjust video noise accroding to the video length
     peft_control: LazyDict | None = None
-    context_parallel_size: int = 1  # Added field with default value
     num_latents_to_drop: int = 0  # number of P-latents to discard after encoding
 
 

--- a/cosmos_predict1/diffusion/training/config/base/model.py
+++ b/cosmos_predict1/diffusion/training/config/base/model.py
@@ -71,6 +71,8 @@ class DefaultModelConfig:
     use_dummy_temporal_dim: bool = False  # Whether to use dummy temporal dimension in data
     adjust_video_noise: bool = False  # whether or not adjust video noise accroding to the video length
     peft_control: LazyDict | None = None
+    context_parallel_size: int = 1    # Added field with default value
+    num_latents_to_drop: int = 0  # number of P-latents to discard after encoding
 
 
 @attrs.define(slots=False)

--- a/cosmos_predict1/diffusion/training/config/base/model.py
+++ b/cosmos_predict1/diffusion/training/config/base/model.py
@@ -71,7 +71,7 @@ class DefaultModelConfig:
     use_dummy_temporal_dim: bool = False  # Whether to use dummy temporal dimension in data
     adjust_video_noise: bool = False  # whether or not adjust video noise accroding to the video length
     peft_control: LazyDict | None = None
-    context_parallel_size: int = 1    # Added field with default value
+    context_parallel_size: int = 1  # Added field with default value
     num_latents_to_drop: int = 0  # number of P-latents to discard after encoding
 
 

--- a/cosmos_predict1/diffusion/training/config/config.py
+++ b/cosmos_predict1/diffusion/training/config/config.py
@@ -102,5 +102,5 @@ def make_config():
     import_all_modules_from_package("cosmos_predict1.diffusion.training.config.video2world", reload=True)
     import_all_modules_from_package("cosmos_predict1.diffusion.training.config.video2world_instruction", reload=True)
     import_all_modules_from_package("cosmos_predict1.diffusion.training.config.video2world_action", reload=True)
-
+    import_all_modules_from_package("cosmos_predict1.diffusion.training.config.world_interpolator", reload=True)
     return c

--- a/cosmos_predict1/diffusion/training/config/config.py
+++ b/cosmos_predict1/diffusion/training/config/config.py
@@ -99,7 +99,7 @@ def make_config():
     register_configs_video2world_instruction()
     register_configs_video2world_action()
     register_configs_world_interpolator()
-    
+
     # experiment config are defined in the experiment folder
     # call import_all_modules_from_package to register them
     import_all_modules_from_package("cosmos_predict1.diffusion.training.config.text2world", reload=True)

--- a/cosmos_predict1/diffusion/training/config/config.py
+++ b/cosmos_predict1/diffusion/training/config/config.py
@@ -30,6 +30,9 @@ from cosmos_predict1.diffusion.training.config.video2world_action.registry impor
 from cosmos_predict1.diffusion.training.config.video2world_instruction.registry import (
     register_configs as register_configs_video2world_instruction,
 )
+from cosmos_predict1.diffusion.training.config.world_interpolator.registry import (
+    register_configs as register_configs_world_interpolator,
+)
 from cosmos_predict1.diffusion.training.models.model import DiffusionModel
 from cosmos_predict1.utils import config
 from cosmos_predict1.utils.config_helper import import_all_modules_from_package
@@ -95,7 +98,8 @@ def make_config():
     register_configs_video2world()
     register_configs_video2world_instruction()
     register_configs_video2world_action()
-
+    register_configs_world_interpolator()
+    
     # experiment config are defined in the experiment folder
     # call import_all_modules_from_package to register them
     import_all_modules_from_package("cosmos_predict1.diffusion.training.config.text2world", reload=True)

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -205,4 +205,3 @@ def register_experiments(cs):
             name=experiment_name,
             node=_item,
         )
-

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -56,8 +56,6 @@ dataloader_train = L(DataLoader)(
     sampler=L(get_sampler)(dataset=example_video_dataset),
     batch_size=1,
     num_workers=0,
-    prefetch_factor=None,
-    drop_last=True,
 )
 dataloader_val = L(DataLoader)(
     dataset=example_video_dataset,
@@ -135,7 +133,7 @@ world_interpolator_7b_example_hdvila = LazyDict(
             ],
             loss_reduce="mean",
             ema=dict(
-                enabled=False,
+                enabled=True,
             ),
             fsdp_enabled=True,
             fsdp=dict(

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -117,7 +117,7 @@ world_interpolator_7b_example_hdvila = LazyDict(
         model_parallel=dict(
             sequence_parallel=False,
             tensor_model_parallel_size=1,
-            context_parallel_size=1,
+            # context_parallel_size=1,
         ),
         model=dict(
             peft_control=dict(
@@ -149,7 +149,7 @@ world_interpolator_7b_example_hdvila = LazyDict(
                 rope_t_extrapolation_ratio=2,
             ),
             adjust_video_noise=True,
-            context_parallel_size=1,
+            # context_parallel_size=1,
             num_latents_to_drop=1,
             conditioner=dict(
                 video_cond_bool=dict(

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -55,7 +55,7 @@ dataloader_train = L(DataLoader)(
     dataset=example_video_dataset,
     sampler=L(get_sampler)(dataset=example_video_dataset),
     batch_size=1,
-    num_workers=0,
+    drop_last=True,
 )
 dataloader_val = L(DataLoader)(
     dataset=example_video_dataset,
@@ -86,7 +86,6 @@ world_interpolator_7b_example_hdvila = LazyDict(
             weight_decay=0.1,
             betas=[0.9, 0.99],
             eps=1e-10,
-            master_weights=False,
         ),
         checkpoint=dict(
             save_iter=200,
@@ -142,7 +141,7 @@ world_interpolator_7b_example_hdvila = LazyDict(
                 checkpoint=True,
                 min_num_params=1024,
                 sharding_group_size=32,
-                sharding_strategy="full",
+                sharding_strategy="hybrid",
             ),
             net=L(VideoExtendGeneralDIT)(
                 rope_h_extrapolation_ratio=1,

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -86,7 +86,7 @@ world_interpolator_7b_example_hdvila = LazyDict(
             weight_decay=0.1,
             betas=[0.9, 0.99],
             eps=1e-10,
-            master_weights = False,
+            master_weights=False,
         ),
         checkpoint=dict(
             save_iter=200,
@@ -121,9 +121,9 @@ world_interpolator_7b_example_hdvila = LazyDict(
             context_parallel_size=1,
         ),
         model=dict(
-            peft_control = dict(
-                enabled = False,
-                mode    = "none",
+            peft_control=dict(
+                enabled=False,
+                mode="none",
             ),
             latent_shape=[
                 16,
@@ -206,5 +206,6 @@ def register_experiments(cs):
             name=experiment_name,
             node=_item,
         )
+
 
 register_experiments(cs)

--- a/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
+++ b/cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py
@@ -206,5 +206,3 @@ def register_experiments(cs):
             node=_item,
         )
 
-
-register_experiments(cs)

--- a/cosmos_predict1/diffusion/training/models/interpolator.py
+++ b/cosmos_predict1/diffusion/training/models/interpolator.py
@@ -33,7 +33,7 @@ class InterpolatorDiffusionModel(ExtendDiffusionModel):
         super().__init__(config)
         self.is_extend_model = True
         self.num_valid_latents = config.latent_shape[1] - config.num_latents_to_drop
-        self.pixel_chunk_duration = config.vae.video_vae.pixel_chunk_duration
+        self.pixel_chunk_duration = config.vae.pixel_chunk_duration
         self.input_image_key = getattr(self.config, "input_image_key", None)
         self.input_data_key = self.config.input_data_key
 

--- a/cosmos_predict1/diffusion/training/train.py
+++ b/cosmos_predict1/diffusion/training/train.py
@@ -27,6 +27,8 @@ from cosmos_predict1.utils.config_helper import get_config_module, override
 from cosmos_predict1.utils.lazy_config import instantiate
 from cosmos_predict1.utils.lazy_config.lazy import LazyConfig
 from cosmos_predict1.utils.parallel_state_helper import is_tp_cp_pp_rank0
+# import debugpy
+# debugpy.listen(("localhost", 5678))
 
 
 @misc.timer("instantiate model")
@@ -116,6 +118,8 @@ For python-based LazyConfig, use "path.key=value".
         action="store_true",
         help="Use only model parallel rank 0 dataloader for faster dataloading! Make sure mock data has same keys as real data.",
     )
+    # debugpy.wait_for_client()
+    # debugpy.breakpoint()
     args = parser.parse_args()
     config_module = get_config_module(args.config)
     config = importlib.import_module(config_module).make_config()

--- a/cosmos_predict1/diffusion/training/train.py
+++ b/cosmos_predict1/diffusion/training/train.py
@@ -27,8 +27,6 @@ from cosmos_predict1.utils.config_helper import get_config_module, override
 from cosmos_predict1.utils.lazy_config import instantiate
 from cosmos_predict1.utils.lazy_config.lazy import LazyConfig
 from cosmos_predict1.utils.parallel_state_helper import is_tp_cp_pp_rank0
-# import debugpy
-# debugpy.listen(("localhost", 5678))
 
 
 @misc.timer("instantiate model")
@@ -118,8 +116,6 @@ For python-based LazyConfig, use "path.key=value".
         action="store_true",
         help="Use only model parallel rank 0 dataloader for faster dataloading! Make sure mock data has same keys as real data.",
     )
-    # debugpy.wait_for_client()
-    # debugpy.breakpoint()
     args = parser.parse_args()
     config_module = get_config_module(args.config)
     config = importlib.import_module(config_module).make_config()

--- a/cosmos_predict1/tokenizer/training/datasets/dataset_provider.py
+++ b/cosmos_predict1/tokenizer/training/datasets/dataset_provider.py
@@ -16,8 +16,10 @@
 """Implementations of dataset settings and augmentations for tokenization
 
 Run this command to interactively debug:
-python3 -m cosmos_predict1.tokenizer.training.datasets.dataset_provider
-
+PYTHONPATH=$(pwd) python -m \
+cosmos_predict1.tokenizer.training.datasets.dataset_provider \
+    --dataset_name hdvila_video \
+    --is_train
 """
 
 from cosmos_predict1.tokenizer.training.datasets.augmentation_provider import (
@@ -109,18 +111,26 @@ def dataset_entry(
 
 
 if __name__ == "__main__":
-    # Example usage / quick test
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_name", default="hdvila_video")
+    parser.add_argument("--dataset_type", default="video")
+    parser.add_argument("--is_train",   action="store_true")
+    parser.add_argument("--resolution", default="720")
+    parser.add_argument("--crop_height", type=int, default=256)
+    parser.add_argument("--num_frames",  type=int, default=25)
+    args = parser.parse_args()
+
     dataset = dataset_entry(
-        dataset_name="davis_video",
-        dataset_type="video",
-        is_train=False,
-        resolution="720",
-        crop_height=256,
-        num_video_frames=25,
+        dataset_name=args.dataset_name,
+        dataset_type=args.dataset_type,
+        is_train=args.is_train,
+        resolution=args.resolution,
+        crop_height=args.crop_height,
+        num_video_frames=args.num_frames,
     )
 
-    # 2) Print out some basic info:
-    print(f"Total samples in dataset: {len(dataset)}")
+    print(f"Total samples: {len(dataset)}")
 
     # 3) Grab one sample (or a few) to check shapes, keys, etc.
     if len(dataset) > 0:

--- a/cosmos_predict1/tokenizer/training/datasets/dataset_provider.py
+++ b/cosmos_predict1/tokenizer/training/datasets/dataset_provider.py
@@ -112,13 +112,14 @@ def dataset_entry(
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--dataset_name", default="hdvila_video")
     parser.add_argument("--dataset_type", default="video")
-    parser.add_argument("--is_train",   action="store_true")
+    parser.add_argument("--is_train", action="store_true")
     parser.add_argument("--resolution", default="720")
     parser.add_argument("--crop_height", type=int, default=256)
-    parser.add_argument("--num_frames",  type=int, default=25)
+    parser.add_argument("--num_frames", type=int, default=25)
     args = parser.parse_args()
 
     dataset = dataset_entry(

--- a/examples/inference_diffusion_WorldInterpolator.md
+++ b/examples/inference_diffusion_WorldInterpolator.md
@@ -1,4 +1,4 @@
-## Inference with diffusion-based Video2World models
+## Inference with diffusion-based WorldInterpolator models
 
 ### Environment setup
 
@@ -39,14 +39,14 @@ The numbers may vary depending on system specs and are for reference only.
 
 
 The inference script is `cosmos_predict1/diffusion/inference/world_interpolator.py`.
-It requires the input argument `--input_image_or_video_path` (image/video input); if the prompt upsampler is disabled, `--prompt` (text input) must also be provided.
+It requires the input argument `--input_image_or_video_path` (video input); if the prompt upsampler is disabled, `--prompt` (text input) must also be provided.
 To see the complete list of available arguments, run
 ```bash
 CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python cosmos_predict1/diffusion/inference/world_interpolator.py --help
 ```
 
 #### Example 1: single generation
-This is the basic example for running inference on the 7B model with a single image. No text prompts are provided here.
+This is the basic example for running inference on the 7B model with input video. No text prompts are provided here.
 ```bash
 
 CUDA_VISIBLE_DEVICES=1 python3 -m cosmos_predict1.diffusion.inference.world_interpolator \

--- a/examples/post-training_diffusion_interpolator.md
+++ b/examples/post-training_diffusion_interpolator.md
@@ -1,0 +1,216 @@
+## Post-training diffusion-based Video2World models
+
+### Model Support Matrix
+
+We support the following Cosmos Diffusion models for post-training. Review the available models and their compute requirements for post-tuning and inference to determine the best model for your use case.
+
+| Model Name                               | Model Status | Compute Requirements for Post-Training |
+|----------------------------------------------|------------------|------------------------------------------|
+| Cosmos-Predict1-7B-Video2World           | **Supported**    | 8 NVIDIA GPUs*                           |
+
+**\*** `H100-80GB` or `A100-80GB` GPUs are recommended.
+
+### Environment setup
+
+Please refer to the Post-training section of [INSTALL.md](/INSTALL.md#post-training) for instructions on environment setup.
+
+### Download checkpoints
+
+1. Generate a [Hugging Face](https://huggingface.co/settings/tokens) access token (if you haven't done so already). Set the access token to `Read` permission (default is `Fine-grained`).
+
+2. Log in to Hugging Face with the access token:
+   ```bash
+   huggingface-cli login
+   ```
+3. Accept the [LlamaGuard-7b terms](https://huggingface.co/meta-llama/LlamaGuard-7b)
+
+4. Download the Cosmos model weights from [Hugging Face](https://huggingface.co/collections/nvidia/cosmos-predict1-67c9d1b97678dbf7669c89a7):
+   ```bash
+   CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/download_diffusion_checkpoints.py --model_sizes 7B --model_types Video2World --checkpoint_dir checkpoints
+   ```
+
+### Examples
+
+Post-training a Cosmos Diffusion-based WFM enables you to train the model to generate videos that are more specific to your use case.
+
+There are 3 steps to post-training: downloading a dataset, preprocessing the data, and post-training the model.
+
+#### 1. Download a Dataset
+
+The first step is to download a dataset with videos.
+
+You must provide a folder containing a collection of videos in **MP4 format**, preferably 720p. These videos should focus be diverse enough to capture different scenarios.
+
+For example, you can use a subset of [HD-VILA-100M](https://github.com/microsoft/XPretrain/tree/main/hd-vila-100m) dataset for post-training.
+
+```bash
+# Download metadata with video urls
+mkdir -p datasets/hdvila
+cd datasets/hdvila
+wget https://huggingface.co/datasets/TempoFunk/hdvila-100M/resolve/main/hdvila-100M.jsonl
+```
+
+Run the following command to download the sample videos used for post-training:
+
+```bash
+# Requirements for Youtube video downloads & video clipping
+pip install pytubefix ffmpeg
+```
+
+```bash
+# The script will downlaod the original HD-VILA-100M videos, save the corresponding clips and the metadata.
+python3 -m scripts.download_tokenizer_example_data --dataset_path datasets/hdvila --N_videos 128 --do_download --do_clip
+```
+
+The downloaded files should be in the following structure:
+```
+datasets/hdvila/
+├── metas/
+│   ├── *.json
+└── videos/
+    └── *.mp4
+```
+
+Finally, register the glob pattern to the mp4 files at [dataset_provider.py](cosmos_predict1/tokenizer/training/datasets/dataset_provider.py), as show below.
+```python
+_VIDEO_PATTERN_DICT = {
+    "hdvila_video": "datasets/hdvila/videos/*mp4",
+}
+```
+
+```bash
+PYTHONPATH=$(pwd) python -m \
+cosmos_predict1.tokenizer.training.datasets.dataset_provider \
+  --dataset_name hdvila_video \
+  --dataset_type video \
+  --is_train true    
+```
+
+**Note**: As will be shown below, different resolution variants of the `hdvila_video` can be obtained by simply passing `hdvila_video<resolution>`. For instance, in the following examples, we use `hdvila_video360` and `hdvila_video720` to refer to the same hdvila videos but resized to the resolution 360p and 720p, respectively, at the time of training.
+
+
+#### 2. Preprocessing the Data
+
+Run the following command to pre-compute T5-XXL embeddings for the video captions used for post-training:
+
+```bash
+# The script will use the provided prompt, save the T5-XXL embeddings in pickle format.
+CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/get_t5_embeddings.py --dataset_path datasets/hdvila
+```
+
+Dataset folder format:
+```
+datasets/hdvila/
+├── metas/
+│   ├── *.txt
+├── videos/
+│   ├── *.mp4
+├── t5_xxl/
+│   ├── *.pickle
+```
+
+#### 3. Post-train the Model
+
+Run the following command to execute an example post-training job with `hdvila` data.
+```bash
+export OUTPUT_ROOT=checkpoints # default value
+torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train --config=cosmos_predict1/diffusion/training/config/config.py -- experiment=world_interpolator_7b_example_hdvila
+```
+
+The model will be post-trained using the above hdvila dataset.
+See the config `world_interpolator_7b_example_hdvila` defined in `cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py` to understand how the dataloader is determined.
+
+```python
+num_frames = 18
+example_video_dataset = L(Dataset)(
+    dataset_dir="datasets/hdvila",
+    sequence_interval=1,
+    num_frames=num_frames,
+    video_size=(720, 1280),
+    start_frame_interval=1,
+)
+
+dataloader_train = L(DataLoader)(
+    dataset=example_video_dataset,
+    sampler=L(get_sampler)(dataset=example_video_dataset),
+    batch_size=1,
+    num_workers=0,
+    prefetch_factor=None,  
+    drop_last=True,
+)
+dataloader_val = L(DataLoader)(
+    dataset=example_video_dataset,
+    sampler=L(get_sampler)(dataset=example_video_dataset),
+    batch_size=1,
+    drop_last=True,
+)
+...
+
+```
+
+The checkpoints will be saved to `${OUTPUT_ROOT}/PROJECT/GROUP/NAME`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_video2world`, `NAME` is `world_interpolator_7b_example_hdvila`.
+
+See the job config to understand how they are determined.
+```python
+world_interpolator_7b_example_hdvila = LazyDict(
+    dict(
+        ...
+        job=dict(
+            project="posttraining",
+            group="diffusion_world_interpolator",
+            name="world_interpolator_7b_example_hdvila",
+        ),
+        ...
+    )
+)
+```
+
+##### Post-train Cosmos-Predict1-7B-Video2World
+
+Run the following command to execute an example post-training job with `cosmos_hdvila_assets` data.
+```bash
+export OUTPUT_ROOT=checkpoints # default value
+torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
+    --config=cosmos_predict1/diffusion/training/config/config.py \
+    -- experiment=world_interpolator_7b_example_hdvila
+```
+
+During the training, the checkpoints will be saved in the below structure.
+```
+checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/
+├── iter_{NUMBER}_reg_model.pt
+├── iter_{NUMBER}_optimizer_model.pt
+```
+
+
+#### 3. Inference with the Post-trained Model Checkpoint
+
+The inference can be done with the same interface as described in [examples/inference_diffusion_WorldInterpolator.md](/examples/inference_diffusion_WorldInterpolator.md.
+
+##### Cosmos-Predict1-7B-Video2World
+
+1. Copying checkpoint to Designated Location
+
+The post-trained checkpoint needs to be copied to `checkpoints/Cosmos-Predict1-7B-WorldInterpolator/model.pt`
+
+For example, if a posttrained checkpoint (ema) with 200 iterations is to be used,
+```bash
+# copy checkpoint to the designated location
+cp checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/iter_000000200_reg_model.pt checkpoints/Cosmos-Predict1-7B-WorldInterpolator/model.pt
+```
+
+2. Running the Inference
+
+This is the basic example for running inference on the post-trained 7B model
+```bash
+CUDA_VISIBLE_DEVICES=1 python3 -m cosmos_predict1.diffusion.inference.world_interpolator \
+    --checkpoint_dir checkpoints \
+    --diffusion_transformer_dir Cosmos-Predict1-7B-WorldInterpolator \
+    --input_image_or_video_path assets/diffusion/interpolation_example.mp4  \
+    --num_input_frames 1 \
+    --offload_prompt_upsampler \
+    --video_save_name diffusion-world-interpolator-7b \
+    --num_video_frames 10 \
+    --num_frame_pairs 2
+```

--- a/examples/post-training_diffusion_interpolator.md
+++ b/examples/post-training_diffusion_interpolator.md
@@ -39,7 +39,7 @@ There are 3 steps to post-training: downloading a dataset, preprocessing the dat
 
 The first step is to download a dataset with videos.
 
-You must provide a folder containing a collection of videos in **MP4 format**, preferably 720p. These videos should focus be diverse enough to capture different scenarios.
+You must provide a folder containing a collection of videos in **MP4 format**, preferably 720p. These videos should be diverse enough to capture different scenarios.
 
 For example, you can use a subset of [HD-VILA-100M](https://github.com/microsoft/XPretrain/tree/main/hd-vila-100m) dataset for post-training.
 

--- a/examples/post-training_diffusion_interpolator.md
+++ b/examples/post-training_diffusion_interpolator.md
@@ -83,7 +83,7 @@ PYTHONPATH=$(pwd) python -m \
 cosmos_predict1.tokenizer.training.datasets.dataset_provider \
   --dataset_name hdvila_video \
   --dataset_type video \
-  --is_train true    
+  --is_train true  
 ```
 
 **Note**: As will be shown below, different resolution variants of the `hdvila_video` can be obtained by simply passing `hdvila_video<resolution>`. For instance, in the following examples, we use `hdvila_video360` and `hdvila_video720` to refer to the same hdvila videos but resized to the resolution 360p and 720p, respectively, at the time of training.

--- a/examples/post-training_diffusion_interpolator.md
+++ b/examples/post-training_diffusion_interpolator.md
@@ -1,4 +1,4 @@
-## Post-training diffusion-based Video2World models
+## Post-training diffusion-based WorldInterpolator model
 
 ### Model Support Matrix
 
@@ -6,7 +6,7 @@ We support the following Cosmos Diffusion models for post-training. Review the a
 
 | Model Name                               | Model Status | Compute Requirements for Post-Training |
 |----------------------------------------------|------------------|------------------------------------------|
-| Cosmos-Predict1-7B-Video2World           | **Supported**    | 8 NVIDIA GPUs*                           |
+| Cosmos-Predict1-7B-WorldInterpolator         | **Supported**    | 4 NVIDIA GPUs*                           |
 
 **\*** `H100-80GB` or `A100-80GB` GPUs are recommended.
 
@@ -54,7 +54,7 @@ Run the following command to download the sample videos used for post-training:
 
 ```bash
 # Requirements for Youtube video downloads & video clipping
-pip install pytubefix ffmpeg
+pip install pytubefix ffmpeg-python
 ```
 
 ```bash
@@ -114,10 +114,18 @@ datasets/hdvila/
 Run the following command to execute an example post-training job with `hdvila` data.
 ```bash
 export OUTPUT_ROOT=checkpoints # default value
-torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train --config=cosmos_predict1/diffusion/training/config/config.py -- experiment=world_interpolator_7b_example_hdvila
+torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
+    --config=cosmos_predict1/diffusion/training/config/config.py \
+    -- experiment=world_interpolator_7b_example_hdvila
 ```
 
-The model will be post-trained using the above hdvila dataset.
+During the training, the checkpoints will be saved in the below structure.
+```
+checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/
+├── iter_{NUMBER}_reg_model.pt
+├── iter_{NUMBER}_optimizer_model.pt
+```
+
 See the config `world_interpolator_7b_example_hdvila` defined in `cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py` to understand how the dataloader is determined.
 
 ```python
@@ -149,7 +157,7 @@ dataloader_val = L(DataLoader)(
 ```
 
 The checkpoints will be saved to `${OUTPUT_ROOT}/PROJECT/GROUP/NAME`.
-In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_video2world`, `NAME` is `world_interpolator_7b_example_hdvila`.
+In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_world_interpolator`, `NAME` is `world_interpolator_7b_example_hdvila`.
 
 See the job config to understand how they are determined.
 ```python
@@ -166,29 +174,11 @@ world_interpolator_7b_example_hdvila = LazyDict(
 )
 ```
 
-##### Post-train Cosmos-Predict1-7B-Video2World
-
-Run the following command to execute an example post-training job with `cosmos_hdvila_assets` data.
-```bash
-export OUTPUT_ROOT=checkpoints # default value
-torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
-    --config=cosmos_predict1/diffusion/training/config/config.py \
-    -- experiment=world_interpolator_7b_example_hdvila
-```
-
-During the training, the checkpoints will be saved in the below structure.
-```
-checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/
-├── iter_{NUMBER}_reg_model.pt
-├── iter_{NUMBER}_optimizer_model.pt
-```
-
-
 #### 3. Inference with the Post-trained Model Checkpoint
 
-The inference can be done with the same interface as described in [examples/inference_diffusion_WorldInterpolator.md](/examples/inference_diffusion_WorldInterpolator.md.
+The inference can be done with the same interface as described in [examples/inference_diffusion_WorldInterpolator.md](/examples/inference_diffusion_WorldInterpolator.md).
 
-##### Cosmos-Predict1-7B-Video2World
+##### Cosmos-Predict1-7B-WorldInterpolator
 
 1. Copying checkpoint to Designated Location
 


### PR DESCRIPTION
#### 1. Download a Dataset

The first step is to download a dataset with videos.

You must provide a folder containing a collection of videos in **MP4 format**, preferably 720p. These videos should focus be diverse enough to capture different scenarios.

For example, you can use a subset of [HD-VILA-100M](https://github.com/microsoft/XPretrain/tree/main/hd-vila-100m) dataset for post-training.

```bash
# Download metadata with video urls
mkdir -p datasets/hdvila
cd datasets/hdvila
wget https://huggingface.co/datasets/TempoFunk/hdvila-100M/resolve/main/hdvila-100M.jsonl
```

Run the following command to download the sample videos used for post-training:

```bash
# Requirements for Youtube video downloads & video clipping
pip install pytubefix ffmpeg-python
```

```bash
# The script will downlaod the original HD-VILA-100M videos, save the corresponding clips and the metadata.
python3 -m scripts.download_tokenizer_example_data --dataset_path datasets/hdvila --N_videos 128 --do_download --do_clip
```

The downloaded files should be in the following structure:
```
datasets/hdvila/
├── metas/
│   ├── *.json
└── videos/
    └── *.mp4
```

Finally, register the glob pattern to the mp4 files at [dataset_provider.py](cosmos_predict1/tokenizer/training/datasets/dataset_provider.py), as show below.
```python
_VIDEO_PATTERN_DICT = {
    "hdvila_video": "datasets/hdvila/videos/*mp4",
}
```

```bash
PYTHONPATH=$(pwd) python -m \
cosmos_predict1.tokenizer.training.datasets.dataset_provider \
  --dataset_name hdvila_video \
  --dataset_type video \
  --is_train true    
```

**Note**: As will be shown below, different resolution variants of the `hdvila_video` can be obtained by simply passing `hdvila_video<resolution>`. For instance, in the following examples, we use `hdvila_video360` and `hdvila_video720` to refer to the same hdvila videos but resized to the resolution 360p and 720p, respectively, at the time of training.


#### 2. Preprocessing the Data

Run the following command to pre-compute T5-XXL embeddings for the video captions used for post-training:

```bash
# The script will use the provided prompt, save the T5-XXL embeddings in pickle format.
CUDA_HOME=$CONDA_PREFIX PYTHONPATH=$(pwd) python scripts/get_t5_embeddings.py --dataset_path datasets/hdvila
```

Dataset folder format:
```
datasets/hdvila/
├── metas/
│   ├── *.txt
├── videos/
│   ├── *.mp4
├── t5_xxl/
│   ├── *.pickle
```

#### 3. Post-train the Model

Run the following command to execute an example post-training job with `hdvila` data.
```bash
export OUTPUT_ROOT=checkpoints # default value
torchrun --nproc_per_node=4 -m cosmos_predict1.diffusion.training.train \
    --config=cosmos_predict1/diffusion/training/config/config.py \
    -- experiment=world_interpolator_7b_example_hdvila
```

During the training, the checkpoints will be saved in the below structure.
```
checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/
├── iter_{NUMBER}_reg_model.pt
├── iter_{NUMBER}_optimizer_model.pt
```

See the config `world_interpolator_7b_example_hdvila` defined in `cosmos_predict1/diffusion/training/config/world_interpolator/experiment.py` to understand how the dataloader is determined.

```python
num_frames = 18
example_video_dataset = L(Dataset)(
    dataset_dir="datasets/hdvila",
    sequence_interval=1,
    num_frames=num_frames,
    video_size=(720, 1280),
    start_frame_interval=1,
)

dataloader_train = L(DataLoader)(
    dataset=example_video_dataset,
    sampler=L(get_sampler)(dataset=example_video_dataset),
    batch_size=1,
    num_workers=0,
    prefetch_factor=None,  
    drop_last=True,
)
dataloader_val = L(DataLoader)(
    dataset=example_video_dataset,
    sampler=L(get_sampler)(dataset=example_video_dataset),
    batch_size=1,
    drop_last=True,
)
...

```

The checkpoints will be saved to `${OUTPUT_ROOT}/PROJECT/GROUP/NAME`.
In the above example, `PROJECT` is `posttraining`, `GROUP` is `diffusion_world_interpolator`, `NAME` is `world_interpolator_7b_example_hdvila`.

See the job config to understand how they are determined.
```python
world_interpolator_7b_example_hdvila = LazyDict(
    dict(
        ...
        job=dict(
            project="posttraining",
            group="diffusion_world_interpolator",
            name="world_interpolator_7b_example_hdvila",
        ),
        ...
    )
)
```

#### 3. Inference with the Post-trained Model Checkpoint

The inference can be done with the same interface as described in [examples/inference_diffusion_WorldInterpolator.md](/examples/inference_diffusion_WorldInterpolator.md).

##### Cosmos-Predict1-7B-WorldInterpolator

1. Copying checkpoint to Designated Location

The post-trained checkpoint needs to be copied to `checkpoints/Cosmos-Predict1-7B-WorldInterpolator/model.pt`

For example, if a posttrained checkpoint (ema) with 200 iterations is to be used,
```bash
# copy checkpoint to the designated location
cp checkpoints/posttraining/diffusion_world_interpolator/world_interpolator_7b_example_hdvila/checkpoints/iter_000000200_reg_model.pt checkpoints/Cosmos-Predict1-7B-WorldInterpolator/model.pt
```

2. Running the Inference

This is the basic example for running inference on the post-trained 7B model
```bash
CUDA_VISIBLE_DEVICES=1 python3 -m cosmos_predict1.diffusion.inference.world_interpolator \
    --checkpoint_dir checkpoints \
    --diffusion_transformer_dir Cosmos-Predict1-7B-WorldInterpolator \
    --input_image_or_video_path assets/diffusion/interpolation_example.mp4  \
    --num_input_frames 1 \
    --offload_prompt_upsampler \
    --video_save_name diffusion-world-interpolator-7b \
    --num_video_frames 10 \
    --num_frame_pairs 2
```