### PR TITLE
Enable CP at load network time

### DIFF
--- a/cosmos_predict1/diffusion/inference/text2world.py
+++ b/cosmos_predict1/diffusion/inference/text2world.py
@@ -17,10 +17,11 @@ import argparse
 import os
 
 import torch
+from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionText2WorldGenerationPipeline
-from cosmos_predict1.utils import log, misc
+from cosmos_predict1.utils import distributed, log, misc
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -94,13 +95,8 @@ def demo(args):
     validate_args(args, inference_type)
 
     if args.num_gpus > 1:
-        from megatron.core import parallel_state
-
-        from cosmos_predict1.utils import distributed
-
         distributed.init()
         parallel_state.initialize_model_parallel(context_parallel_size=args.num_gpus)
-        process_group = parallel_state.get_context_parallel_group()
 
     # Initialize text2world generation model pipeline
     pipeline = DiffusionText2WorldGenerationPipeline(
@@ -123,9 +119,6 @@ def demo(args):
         num_video_frames=args.num_video_frames,
         seed=args.seed,
     )
-
-    if args.num_gpus > 1:
-        pipeline.model.net.enable_context_parallel(process_group)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/video2world_multiview.py
+++ b/cosmos_predict1/diffusion/inference/video2world_multiview.py
@@ -17,6 +17,7 @@ import argparse
 import os
 
 import torch
+from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import (
     add_common_arguments,
@@ -28,7 +29,7 @@ from cosmos_predict1.diffusion.inference.inference_utils import (
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import (
     DiffusionVideo2WorldMultiviewGenerationPipeline,
 )
-from cosmos_predict1.utils import log, misc
+from cosmos_predict1.utils import distributed, log, misc
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -143,13 +144,8 @@ def demo(args):
     validate_args(args, inference_type)
 
     if args.num_gpus > 1:
-        from megatron.core import parallel_state
-
-        from cosmos_predict1.utils import distributed
-
         distributed.init()
         parallel_state.initialize_model_parallel(context_parallel_size=args.num_gpus)
-        process_group = parallel_state.get_context_parallel_group()
 
     # Initialize video2world generation model pipeline
     pipeline = DiffusionVideo2WorldMultiviewGenerationPipeline(
@@ -171,9 +167,6 @@ def demo(args):
         seed=args.seed,
         num_input_frames=args.num_input_frames,
     )
-
-    if args.num_gpus > 1:
-        pipeline.model.net.enable_context_parallel(process_group)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:


### PR DESCRIPTION
This PR fixes issue #80 when `--offload_diffusion_transformer` is added as an inference argument. It enables CP after the DiT is loaded.