### PR TITLE
Add optional benchmarking for inference scripts

### DIFF
--- a/cosmos_predict1/autoregressive/inference/base.py
+++ b/cosmos_predict1/autoregressive/inference/base.py
@@ -21,7 +21,7 @@ import torch
 
 from cosmos_predict1.autoregressive.inference.world_generation_pipeline import ARBaseGenerationPipeline
 from cosmos_predict1.autoregressive.utils.inference import add_common_arguments, load_vision_input, validate_args
-from cosmos_predict1.utils import log
+from cosmos_predict1.utils import log, benchmark
 
 
 def parse_args():
@@ -34,6 +34,11 @@ def parse_args():
         default="Cosmos-Predict1-4B",
     )
     parser.add_argument("--input_type", type=str, default="video", help="Type of input", choices=["image", "video"])
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
     args = parser.parse_args()
     return args
 
@@ -84,6 +89,8 @@ def main(args):
         disable_guardrail=args.disable_guardrail,
         parallel_size=args.num_gpus,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Load input image(s) or video(s)
     input_videos = load_vision_input(

--- a/cosmos_predict1/autoregressive/inference/video2world.py
+++ b/cosmos_predict1/autoregressive/inference/video2world.py
@@ -21,7 +21,7 @@ import torch
 
 from cosmos_predict1.autoregressive.inference.world_generation_pipeline import ARVideo2WorldGenerationPipeline
 from cosmos_predict1.autoregressive.utils.inference import add_common_arguments, load_vision_input, validate_args
-from cosmos_predict1.utils import log
+from cosmos_predict1.utils import log, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file
 
 
@@ -49,6 +49,11 @@ def parse_args():
         "--offload_text_encoder_model",
         action="store_true",
         help="Offload T5 model after inference",
+    )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
     )
     args = parser.parse_args()
     return args
@@ -101,6 +106,8 @@ def main(args):
         disable_guardrail=args.disable_guardrail,
         parallel_size=args.num_gpus,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Load input image(s) or video(s)
     input_videos = load_vision_input(

--- a/cosmos_predict1/diffusion/inference/text2world.py
+++ b/cosmos_predict1/diffusion/inference/text2world.py
@@ -21,7 +21,7 @@ from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionText2WorldGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -62,7 +62,11 @@ def parse_arguments() -> argparse.Namespace:
         default=250,
         help="Skip prompt upsampler for better robustness if the number of words in the prompt is greater than this value",
     )
-
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
     return parser.parse_args()
 
 
@@ -119,6 +123,8 @@ def demo(args):
         num_video_frames=args.num_video_frames,
         seed=args.seed,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/text2world_multiview.py
+++ b/cosmos_predict1/diffusion/inference/text2world_multiview.py
@@ -21,7 +21,7 @@ from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, remove_argument, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionText2WorldMultiviewGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -90,6 +90,11 @@ def parse_arguments() -> argparse.Namespace:
         default=10.0,
         help="frame_repeat number to be used as negative condition",
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
 
     return parser.parse_args()
 
@@ -146,6 +151,8 @@ def demo(args):
         seed=args.seed,
         n_views=args.n_views,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/video2world.py
+++ b/cosmos_predict1/diffusion/inference/video2world.py
@@ -26,7 +26,7 @@ from cosmos_predict1.diffusion.inference.inference_utils import (
     validate_args,
 )
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionVideo2WorldGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -71,6 +71,11 @@ def parse_arguments() -> argparse.Namespace:
         default=1,
         help="Number of input frames for video2world prediction",
         choices=[1, 9],
+    )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
     )
 
     return parser.parse_args()
@@ -130,6 +135,8 @@ def demo(args):
         seed=args.seed,
         num_input_frames=args.num_input_frames,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/video2world_action.py
+++ b/cosmos_predict1/diffusion/inference/video2world_action.py
@@ -21,7 +21,7 @@ from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, remove_argument, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionVideo2WorldActionGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import save_video
 
 torch.enable_grad(False)
@@ -74,6 +74,11 @@ def parse_arguments() -> argparse.Namespace:
         default=1,
         help="Number of loops to generate video",
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
 
     return parser.parse_args()
 
@@ -124,6 +129,8 @@ def demo(args: argparse.Namespace) -> None:
         seed=args.seed,
         num_input_frames=args.num_input_frames,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     generated_output = pipeline.generate(
         action_path=args.action_annotation_path,

--- a/cosmos_predict1/diffusion/inference/video2world_multiview.py
+++ b/cosmos_predict1/diffusion/inference/video2world_multiview.py
@@ -29,7 +29,7 @@ from cosmos_predict1.diffusion.inference.inference_utils import (
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import (
     DiffusionVideo2WorldMultiviewGenerationPipeline,
 )
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -111,6 +111,11 @@ def parse_arguments() -> argparse.Namespace:
         help="Number of input frames for video2world prediction",
         choices=[1, 9],
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
 
     return parser.parse_args()
 
@@ -168,6 +173,8 @@ def demo(args):
         num_input_frames=args.num_input_frames,
         n_views=args.n_views,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/video2world_view_extend_multiview.py
+++ b/cosmos_predict1/diffusion/inference/video2world_view_extend_multiview.py
@@ -21,7 +21,7 @@ from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, remove_argument
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionViewExtendMultiviewGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -134,6 +134,11 @@ def parse_arguments() -> argparse.Namespace:
         help="Number of frames to skip in the view_condition_video from the start, useful if you want to extend a segment "
         "of the input video rather than from the beginning.",
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
     return parser.parse_args()
 
 
@@ -190,6 +195,8 @@ def demo(args):
         num_input_frames=args.num_input_frames,
         n_views=args.n_views,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/diffusion/inference/world_interpolator.py
+++ b/cosmos_predict1/diffusion/inference/world_interpolator.py
@@ -33,7 +33,7 @@ from megatron.core import parallel_state
 
 from cosmos_predict1.diffusion.inference.inference_utils import add_common_arguments, check_input_frames, validate_args
 from cosmos_predict1.diffusion.inference.world_generation_pipeline import DiffusionWorldInterpolatorGenerationPipeline
-from cosmos_predict1.utils import distributed, log, misc
+from cosmos_predict1.utils import distributed, log, misc, benchmark
 from cosmos_predict1.utils.io import read_prompts_from_file, save_video
 
 torch.enable_grad(False)
@@ -99,6 +99,11 @@ def parse_arguments() -> argparse.Namespace:
         "frame pair is processed (e.g., (x0, x1) for step_size=1, (x0, x2) for step_size=2). Higher values allow processing more "
         "pairs up to the maximum possible with the given step_size.",
     )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run the generation in benchmark mode. It means that generation will be rerun a few times and the average generation time will be shown.",
+    )
     return parser.parse_args()
 
 
@@ -157,6 +162,8 @@ def demo(args):
         num_frame_pairs=args.num_frame_pairs,
         frame_stride=args.frame_stride,
     )
+    if args.benchmark:
+        pipeline.generate = benchmark.benchmark_decorator()(pipeline.generate)
 
     # Handle multiple prompts if prompt file is provided
     if args.batch_input_path:

--- a/cosmos_predict1/utils/benchmark.py
+++ b/cosmos_predict1/utils/benchmark.py
@@ -1,0 +1,35 @@
+import time
+import functools
+
+import torch
+
+from cosmos_predict1.utils import log
+
+
+def benchmark_decorator(profiling_iterations_count=3, warmup_iterations_count=1):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            time_sum = 0
+            result = None
+            total_runs = warmup_iterations_count + profiling_iterations_count
+            
+            for i in range(total_runs):
+                if i >= warmup_iterations_count:
+                    torch.cuda.synchronize()
+                    start_time = time.perf_counter()
+                
+                result = func(*args, **kwargs)
+                
+                if i >= warmup_iterations_count:
+                    torch.cuda.synchronize()
+                    time_sum += time.perf_counter() - start_time
+            
+            if profiling_iterations_count > 0:
+                log.critical(f"The benchmarked generation time for {func.__name__} is {time_sum / profiling_iterations_count} seconds.")
+            
+            return result
+        
+        return wrapper
+    
+    return decorator


### PR DESCRIPTION
This PR adds an option to run a simple benchmark for all inference scripts. When the `--benchmark` option is used, four calls to `pipeline.generate` are executed, and the average run time of the last three is logged (the first is used as a warm-up).

It's similar to this [PR](https://github.com/nvidia-cosmos/cosmos-predict2/pull/37) in predict 2.

tested with: `cosmos_predict1/autoregressive/inference/base.py` and `cosmos_predict1/diffusion/inference/text2world.py` as it takes considerable time to run all the pipelines. 